### PR TITLE
Switch extraction fetcher to curl_cffi for Cloudflare-fronted sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -516,6 +516,16 @@ These documents support research publication and developer onboarding.
 
 ---
 
+# Dependencies
+
+Python dependencies are listed in `requirements.txt`. A few notes worth
+flagging for contributors working on the extraction stage:
+
+- **curl_cffi** is used for all HTTP fetches in `bioscancast/extraction/fetcher.py`. It wraps libcurl with browser TLS-fingerprint impersonation (Chrome by default), which lets us reach Cloudflare-fronted news sources (e.g. Reuters) that reject the default Python TLS stack used by `httpx`/`requests` with HTTP 401/403. The impersonation profile is configurable via `ExtractionConfig.impersonate`. See [issue #18](https://github.com/algorithmicgovernance/BioScanCast/issues/18) for background.
+- **Live network tests** are marked `@pytest.mark.live` and skipped by default. Run them with `pytest --live` to verify the fetcher still works against real CDN-fronted endpoints.
+
+---
+
 # Running the Pipeline
 
 Example:

--- a/bioscancast/extraction/config.py
+++ b/bioscancast/extraction/config.py
@@ -10,6 +10,4 @@ class ExtractionConfig:
     pdf_max_pages: int = 100
     chunk_target_tokens: int = 800
     chunk_max_tokens: int = 1500
-    user_agent: str = (
-        "BioScanCast/0.1 (+https://github.com/algorithmicgovernance/BioScanCast)"
-    )
+    impersonate: str = "chrome"

--- a/bioscancast/extraction/fetcher.py
+++ b/bioscancast/extraction/fetcher.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Optional
 
-import httpx
+from curl_cffi import requests as curl_requests
 
 from .config import ExtractionConfig
 
@@ -52,20 +52,48 @@ def fetch(
     *,
     config: ExtractionConfig | None = None,
 ) -> FetchResult:
-    """Fetch a URL and return the result. Never raises on network errors."""
+    """Fetch a URL and return the result. Never raises on network errors.
+
+    Uses curl_cffi with a browser TLS fingerprint (configurable via
+    ExtractionConfig.impersonate) to avoid Cloudflare/JA3-based blocks that
+    reject httpx and requests. The impersonation profile sets a matching
+    User-Agent automatically.
+    """
     cfg = config or ExtractionConfig()
     fetched_at = datetime.now(timezone.utc)
 
     try:
-        with httpx.Client(
-            follow_redirects=True,
-            timeout=httpx.Timeout(cfg.fetch_timeout_seconds),
-            headers={"User-Agent": cfg.user_agent},
-        ) as client:
-            with client.stream("GET", url) as response:
-                # Check Content-Length header first
-                content_length = response.headers.get("content-length")
-                if content_length and int(content_length) > cfg.fetch_max_bytes:
+        # curl_cffi's streaming Response is not a context manager in the
+        # installed version, so we close it explicitly in a finally block.
+        response = curl_requests.get(
+            url,
+            stream=True,
+            timeout=cfg.fetch_timeout_seconds,
+            impersonate=cfg.impersonate,
+            allow_redirects=True,
+        )
+        try:
+            content_length = response.headers.get("content-length")
+            if content_length and int(content_length) > cfg.fetch_max_bytes:
+                return FetchResult(
+                    url=url,
+                    final_url=str(response.url),
+                    status_code=response.status_code,
+                    content_type=_normalize_content_type(
+                        response.headers.get("content-type")
+                    ),
+                    content_bytes=None,
+                    fetched_at=fetched_at,
+                    error=f"Content-Length {content_length} exceeds max {cfg.fetch_max_bytes} bytes",
+                )
+
+            chunks = []
+            total = 0
+            # chunk_size is not honoured by curl_cffi (warns); curl picks
+            # the buffer size internally.
+            for chunk in response.iter_content():
+                total += len(chunk)
+                if total > cfg.fetch_max_bytes:
                     return FetchResult(
                         url=url,
                         final_url=str(response.url),
@@ -75,47 +103,31 @@ def fetch(
                         ),
                         content_bytes=None,
                         fetched_at=fetched_at,
-                        error=f"Content-Length {content_length} exceeds max {cfg.fetch_max_bytes} bytes",
+                        error=f"Response exceeded max {cfg.fetch_max_bytes} bytes during streaming",
                     )
+                chunks.append(chunk)
 
-                # Stream and accumulate bytes, checking size limit
-                chunks = []
-                total = 0
-                for chunk in response.iter_bytes(chunk_size=65536):
-                    total += len(chunk)
-                    if total > cfg.fetch_max_bytes:
-                        return FetchResult(
-                            url=url,
-                            final_url=str(response.url),
-                            status_code=response.status_code,
-                            content_type=_normalize_content_type(
-                                response.headers.get("content-type")
-                            ),
-                            content_bytes=None,
-                            fetched_at=fetched_at,
-                            error=f"Response exceeded max {cfg.fetch_max_bytes} bytes during streaming",
-                        )
-                    chunks.append(chunk)
+            content_bytes = b"".join(chunks)
+            raw_ct = _normalize_content_type(
+                response.headers.get("content-type")
+            )
 
-                content_bytes = b"".join(chunks)
-                raw_ct = _normalize_content_type(
-                    response.headers.get("content-type")
-                )
+            # Fall back to magic-byte sniffing if header is
+            # missing or generic (e.g. application/octet-stream)
+            if not raw_ct or raw_ct == "application/octet-stream":
+                raw_ct = _sniff_content_type(content_bytes) or raw_ct
 
-                # Fall back to magic-byte sniffing if header is
-                # missing or generic (e.g. application/octet-stream)
-                if not raw_ct or raw_ct == "application/octet-stream":
-                    raw_ct = _sniff_content_type(content_bytes) or raw_ct
-
-                return FetchResult(
-                    url=url,
-                    final_url=str(response.url),
-                    status_code=response.status_code,
-                    content_type=raw_ct,
-                    content_bytes=content_bytes,
-                    fetched_at=fetched_at,
-                    error=None,
-                )
+            return FetchResult(
+                url=url,
+                final_url=str(response.url),
+                status_code=response.status_code,
+                content_type=raw_ct,
+                content_bytes=content_bytes,
+                fetched_at=fetched_at,
+                error=None,
+            )
+        finally:
+            response.close()
 
     except Exception as exc:
         logger.warning("Fetch failed for %s: %s", url, exc)

--- a/bioscancast/tests/conftest.py
+++ b/bioscancast/tests/conftest.py
@@ -1,0 +1,37 @@
+"""Pytest configuration shared across the bioscancast test suite.
+
+Adds a `--live` CLI flag that opts into tests marked `@pytest.mark.live`,
+which require network access to real third-party services (e.g. CDN-fronted
+sources used to verify the curl_cffi fetcher against Cloudflare-style
+TLS-fingerprint blocks). By default these tests are skipped so the suite
+stays hermetic in CI.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--live",
+        action="store_true",
+        default=False,
+        help="Run tests marked @pytest.mark.live (hits real network endpoints).",
+    )
+
+
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers",
+        "live: test requires real network access; opt in with --live.",
+    )
+
+
+def pytest_collection_modifyitems(config, items):
+    if config.getoption("--live"):
+        return
+    skip_live = pytest.mark.skip(reason="needs --live to run (hits real network)")
+    for item in items:
+        if "live" in item.keywords:
+            item.add_marker(skip_live)

--- a/bioscancast/tests/test_extraction_fetcher.py
+++ b/bioscancast/tests/test_extraction_fetcher.py
@@ -2,14 +2,12 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
-import httpx
 import pytest
 
 from bioscancast.extraction.config import ExtractionConfig
-from bioscancast.extraction.fetcher import FetchResult, fetch, _sniff_content_type
+from bioscancast.extraction.fetcher import fetch, _sniff_content_type
 
 
 # ---------------------------------------------------------------------------
@@ -34,11 +32,11 @@ class TestSniffContentType:
 
 
 # ---------------------------------------------------------------------------
-# Helpers: fake httpx responses
+# Helpers: fake curl_cffi responses
 # ---------------------------------------------------------------------------
 
 class FakeResponse:
-    """Minimal stand-in for httpx.Response used in stream context."""
+    """Minimal stand-in for a curl_cffi.requests streaming Response."""
 
     def __init__(
         self,
@@ -49,33 +47,16 @@ class FakeResponse:
         url: str = "https://example.com/page",
     ):
         self.status_code = status_code
-        self.headers = httpx.Headers(headers or {})
-        self.url = httpx.URL(url)
+        # curl_cffi headers behave like a case-insensitive dict; a plain dict
+        # with lowercase keys is sufficient for the fetcher's lookups.
+        self.headers = {k.lower(): v for k, v in (headers or {}).items()}
+        self.url = url
         self._chunks = chunks or [b"<html><body>Hello</body></html>"]
 
-    def iter_bytes(self, chunk_size: int = 65536):
+    def iter_content(self):
         yield from self._chunks
 
-    def __enter__(self):
-        return self
-
-    def __exit__(self, *args):
-        pass
-
-
-class FakeClient:
-    """Minimal stand-in for httpx.Client."""
-
-    def __init__(self, response: FakeResponse):
-        self._response = response
-
-    def stream(self, method, url, **kwargs):
-        return self._response
-
-    def __enter__(self):
-        return self
-
-    def __exit__(self, *args):
+    def close(self):
         pass
 
 
@@ -84,9 +65,11 @@ class FakeClient:
 # ---------------------------------------------------------------------------
 
 class TestFetch:
-    def _patch_client(self, response: FakeResponse):
-        client = FakeClient(response)
-        return patch("bioscancast.extraction.fetcher.httpx.Client", return_value=client)
+    def _patch_get(self, response: FakeResponse):
+        return patch(
+            "bioscancast.extraction.fetcher.curl_requests.get",
+            return_value=response,
+        )
 
     def test_successful_html_fetch(self):
         resp = FakeResponse(
@@ -95,7 +78,7 @@ class TestFetch:
             chunks=[b"<html><body>Hello world</body></html>"],
             url="https://example.com/page",
         )
-        with self._patch_client(resp):
+        with self._patch_get(resp):
             result = fetch("https://example.com/page")
 
         assert result.error is None
@@ -110,7 +93,7 @@ class TestFetch:
             headers={},
             chunks=[b"%PDF-1.7 fake pdf content"],
         )
-        with self._patch_client(resp):
+        with self._patch_get(resp):
             result = fetch("https://example.com/report")
 
         assert result.content_type == "application/pdf"
@@ -121,7 +104,7 @@ class TestFetch:
             headers={"content-type": "application/octet-stream"},
             chunks=[b"<!DOCTYPE html><html><body>Hi</body></html>"],
         )
-        with self._patch_client(resp):
+        with self._patch_get(resp):
             result = fetch("https://example.com/page")
 
         assert result.content_type == "text/html"
@@ -136,7 +119,7 @@ class TestFetch:
             chunks=[b"small"],
         )
         config = ExtractionConfig(fetch_max_bytes=1000)
-        with self._patch_client(resp):
+        with self._patch_get(resp):
             result = fetch("https://example.com/big.pdf", config=config)
 
         assert result.error is not None
@@ -150,7 +133,7 @@ class TestFetch:
             chunks=[b"a" * 600, b"b" * 600],
         )
         config = ExtractionConfig(fetch_max_bytes=1000)
-        with self._patch_client(resp):
+        with self._patch_get(resp):
             result = fetch("https://example.com/page", config=config)
 
         assert result.error is not None
@@ -159,8 +142,8 @@ class TestFetch:
 
     def test_network_error_returns_fetch_result(self):
         with patch(
-            "bioscancast.extraction.fetcher.httpx.Client",
-            side_effect=httpx.ConnectError("Connection refused"),
+            "bioscancast.extraction.fetcher.curl_requests.get",
+            side_effect=ConnectionError("Connection refused"),
         ):
             result = fetch("https://unreachable.example.com")
 
@@ -176,7 +159,7 @@ class TestFetch:
             chunks=[b"<html>redirected</html>"],
             url="https://example.com/final-page",
         )
-        with self._patch_client(resp):
+        with self._patch_get(resp):
             result = fetch("https://example.com/old-page")
 
         assert result.final_url == "https://example.com/final-page"
@@ -188,7 +171,46 @@ class TestFetch:
             headers={"content-type": "text/html"},
             chunks=[b"<html></html>"],
         )
-        with self._patch_client(resp):
+        with self._patch_get(resp):
             result = fetch("https://example.com/page")
 
         assert result.fetched_at.tzinfo is not None
+
+    def test_impersonate_passed_to_curl_cffi(self):
+        """The configured impersonation profile reaches curl_cffi.get."""
+        resp = FakeResponse(
+            status_code=200,
+            headers={"content-type": "text/html"},
+            chunks=[b"<html></html>"],
+        )
+        config = ExtractionConfig(impersonate="firefox")
+        with patch(
+            "bioscancast.extraction.fetcher.curl_requests.get",
+            return_value=resp,
+        ) as mock_get:
+            fetch("https://example.com/page", config=config)
+
+        kwargs = mock_get.call_args.kwargs
+        assert kwargs["impersonate"] == "firefox"
+        assert kwargs["stream"] is True
+        assert kwargs["allow_redirects"] is True
+
+
+# ---------------------------------------------------------------------------
+# Live integration test: opt-in with `pytest -m live`.
+# Confirms curl_cffi successfully fetches a Cloudflare-fronted URL that
+# httpx/requests would 401/403 on. Skipped by default to keep CI offline.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.live
+def test_live_cloudflare_fronted_fetch():
+    # Reuters is the canonical case from the docling eval (see issue #18).
+    # Pick a stable landing page rather than a dated article.
+    url = "https://www.reuters.com/"
+    result = fetch(url)
+    assert result.error is None, f"fetch errored: {result.error}"
+    assert result.status_code == 200, (
+        f"expected 200 from Cloudflare-fronted URL, got {result.status_code}"
+    )
+    assert result.content_bytes is not None
+    assert result.content_type == "text/html"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 rank-bm25
 numpy
 
-httpx>=0.27,<1.0 # HTTP client with streaming support
+curl_cffi>=0.7,<1.0 # HTTP client with streaming support and browser TLS-fingerprint impersonation (Cloudflare workaround)
 trafilatura>=1.12,<2.0 # HTML main-content extraction (strips nav, ads, boilerplate)
 beautifulsoup4>=4.12,<5.0 # HTML parsing for heading hierarchy and table recovery (transitive dep of trafilatura, pinned explicitly for direct usage)
 PyMuPDF>=1.24,<2.0 # PDF text and table extraction (imports as 'fitz')


### PR DESCRIPTION
## Summary

- Replaces httpx with `curl_cffi` in `bioscancast/extraction/fetcher.py` so HTTP fetches use a browser TLS fingerprint (Chrome by default). This gets past Cloudflare/JA3-based blocks that returned HTTP 401 on Reuters and intermittent 403s on CIDRAP during the docling eval.
- `ExtractionConfig.user_agent` is replaced with `.impersonate` (`"chrome"` default); the impersonation profile sets a matching browser UA automatically.
- Streaming, the 25 MB cap, Content-Length pre-check, magic-byte sniffing, and the never-raise-on-network-errors contract are preserved. Uses try/finally + `response.close()` since the streaming `Response` in curl_cffi 0.15.0 isn't a context manager.
- New `tests/conftest.py` registers a `live` pytest marker and a `--live` CLI flag; live integration tests are skipped by default.
- New live test hits `https://www.reuters.com/` to confirm the Cloudflare path actually works end-to-end.
- README gains a Dependencies section explaining the curl_cffi choice and the `pytest --live` opt-in.

Closes #18.

## Test plan

- [x] `pytest bioscancast/tests/` — 179 passed, 1 skipped (live)
- [x] `pytest bioscancast/tests/test_extraction_fetcher.py --live` — 15 passed (Reuters returns 200 + HTML, confirming the Cloudflare bypass)
- [ ] Reviewer: spot-check that no other module still expects `ExtractionConfig.user_agent` (grep confirms only the new `impersonate` field is referenced)

🤖 Generated with [Claude Code](https://claude.com/claude-code)