### PR TITLE
Search/filter dashboard chokepoint + relevance ranking

### DIFF
--- a/bioscancast/datasets/biosecurity_sources.py
+++ b/bioscancast/datasets/biosecurity_sources.py
@@ -68,19 +68,19 @@ DASHBOARD_LOOKUP: dict[str, list[DashboardEntry]] = {
             snippet="WHO situation reports with weekly case counts, country breakdowns, and public-health guidance for ongoing outbreaks including mpox.",
         ),
         DashboardEntry(
-            url="https://www.cdc.gov/mpox/data-research/index.html",
-            title="CDC mpox data and research dashboard for the United States",
-            snippet="CDC tracking of US mpox cases, demographic data, vaccination coverage, and outbreak response.",
+            url="https://www.cdc.gov/monkeypox/situation-summary/index.html",
+            title="CDC mpox current situation summary: confirmed cases in the United States",
+            snippet="CDC current situation summary for mpox, with US confirmed case counts, clade information, demographics, and outbreak response.",
         ),
     ],
     "ebola": [
         DashboardEntry(
-            url="https://www.afro.who.int/health-topics/ebola-virus-disease",
+            url="https://www.afro.who.int/health-topics/ebola-disease",
             title="WHO Africa Ebola virus disease outbreak surveillance and case counts",
             snippet="WHO regional office for Africa tracking of Ebola virus disease outbreaks, confirmed and suspected cases, deaths, and response across African countries.",
         ),
         DashboardEntry(
-            url="https://www.cdc.gov/ebola/index.html",
+            url="https://www.cdc.gov/ebola/about/index.html",
             title="CDC Ebola virus disease outbreak history and case counts",
             snippet="CDC information on current and historical Ebola virus disease outbreaks worldwide, with case counts, deaths, and US public-health response.",
         ),

--- a/bioscancast/datasets/biosecurity_sources.py
+++ b/bioscancast/datasets/biosecurity_sources.py
@@ -1,34 +1,112 @@
 """Known biosecurity dashboard URLs by pathogen.
 
-v1 — flagged for iteration after first benchmark run.
-The dashboard list and routing logic will need updating as new outbreaks emerge
-and data portals change.
+v1 — flagged for iteration after first benchmark run. The dashboard list
+and routing logic will need updating as new outbreaks emerge and data
+portals change.
+
+Each entry carries a pathogen-specific ``title`` and ``snippet`` so that
+the heuristic filter and the LLM-rescue path have real signal to work
+with. The earlier convention ("Dashboard: cdc.gov" with a generic
+snippet) produced keyword_overlap_score = 0.000 across the board — see
+issue #14 and the q7/q12 live-run findings.
 """
 
-DASHBOARD_LOOKUP: dict[str, list[str]] = {
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class DashboardEntry:
+    """A curated authoritative source for a pathogen.
+
+    The title and snippet are intended to be readable as a search result
+    in their own right: pathogen name, the kind of data the page hosts,
+    and the publisher. They feed both the keyword-overlap heuristic and
+    the LLM-rescue path.
+    """
+
+    url: str
+    title: str
+    snippet: str
+
+
+DASHBOARD_LOOKUP: dict[str, list[DashboardEntry]] = {
     "h5n1": [
-        "https://www.cdc.gov/bird-flu/situation-summary/",
-        "https://www.who.int/teams/global-influenza-programme/avian-influenza",
+        DashboardEntry(
+            url="https://www.cdc.gov/bird-flu/situation-summary/",
+            title="CDC H5N1 bird flu situation summary: human cases and outbreaks in the United States",
+            snippet="CDC tracking of H5N1 avian influenza human cases, affected livestock herds, and public-health response in the US.",
+        ),
+        DashboardEntry(
+            url="https://www.who.int/teams/global-influenza-programme/avian-influenza",
+            title="WHO Global Influenza Programme: avian influenza A(H5N1) human cases and surveillance",
+            snippet="WHO monitoring of human H5N1 cases, animal-to-human spillover events, and global surveillance reporting.",
+        ),
     ],
     "avian influenza": [
-        "https://www.cdc.gov/bird-flu/situation-summary/",
-        "https://www.who.int/teams/global-influenza-programme/avian-influenza",
+        DashboardEntry(
+            url="https://www.cdc.gov/bird-flu/situation-summary/",
+            title="CDC H5N1 bird flu situation summary: human cases and outbreaks in the United States",
+            snippet="CDC tracking of H5N1 avian influenza human cases, affected livestock herds, and public-health response in the US.",
+        ),
+        DashboardEntry(
+            url="https://www.who.int/teams/global-influenza-programme/avian-influenza",
+            title="WHO Global Influenza Programme: avian influenza A(H5N1) human cases and surveillance",
+            snippet="WHO monitoring of human H5N1 cases, animal-to-human spillover events, and global surveillance reporting.",
+        ),
     ],
     "mpox": [
-        "https://ourworldindata.org/mpox",
-        "https://www.who.int/emergencies/situation-reports",
-        "https://www.cdc.gov/mpox/data-research/index.html",
+        DashboardEntry(
+            url="https://ourworldindata.org/mpox",
+            title="Our World in Data mpox tracker: global confirmed cases and deaths",
+            snippet="OWID dashboard tracking cumulative confirmed mpox cases and deaths globally, broken down by country and region, updated from national health agencies.",
+        ),
+        DashboardEntry(
+            url="https://www.who.int/emergencies/situation-reports",
+            title="WHO situation reports including the multi-country mpox outbreak",
+            snippet="WHO situation reports with weekly case counts, country breakdowns, and public-health guidance for ongoing outbreaks including mpox.",
+        ),
+        DashboardEntry(
+            url="https://www.cdc.gov/mpox/data-research/index.html",
+            title="CDC mpox data and research dashboard for the United States",
+            snippet="CDC tracking of US mpox cases, demographic data, vaccination coverage, and outbreak response.",
+        ),
     ],
     "ebola": [
-        "https://www.afro.who.int/health-topics/ebola-virus-disease",
-        "https://www.cdc.gov/ebola/index.html",
+        DashboardEntry(
+            url="https://www.afro.who.int/health-topics/ebola-virus-disease",
+            title="WHO Africa Ebola virus disease outbreak surveillance and case counts",
+            snippet="WHO regional office for Africa tracking of Ebola virus disease outbreaks, confirmed and suspected cases, deaths, and response across African countries.",
+        ),
+        DashboardEntry(
+            url="https://www.cdc.gov/ebola/index.html",
+            title="CDC Ebola virus disease outbreak history and case counts",
+            snippet="CDC information on current and historical Ebola virus disease outbreaks worldwide, with case counts, deaths, and US public-health response.",
+        ),
     ],
     "covid-19": [
-        "https://ourworldindata.org/coronavirus",
-        "https://www.who.int/emergencies/diseases/novel-coronavirus-2019/situation-reports",
+        DashboardEntry(
+            url="https://ourworldindata.org/coronavirus",
+            title="Our World in Data COVID-19 tracker: global cases, deaths, and vaccinations",
+            snippet="OWID dashboard tracking cumulative COVID-19 confirmed cases, deaths, hospitalizations, and vaccination coverage globally by country.",
+        ),
+        DashboardEntry(
+            url="https://www.who.int/emergencies/diseases/novel-coronavirus-2019/situation-reports",
+            title="WHO COVID-19 situation reports and global case counts",
+            snippet="WHO situation reports with updates on COVID-19 confirmed cases, deaths, variant tracking, and country-level data.",
+        ),
     ],
     "marburg": [
-        "https://www.who.int/news-room/fact-sheets/detail/marburg-virus-disease",
-        "https://www.cdc.gov/marburg/index.html",
+        DashboardEntry(
+            url="https://www.who.int/news-room/fact-sheets/detail/marburg-virus-disease",
+            title="WHO Marburg virus disease facts and outbreak case counts",
+            snippet="WHO factsheet on Marburg virus disease including transmission, symptoms, case-fatality ratio, and historical outbreak case and death counts.",
+        ),
+        DashboardEntry(
+            url="https://www.cdc.gov/marburg/index.html",
+            title="CDC Marburg virus disease outbreaks and surveillance",
+            snippet="CDC information on Marburg virus disease outbreaks worldwide, case counts, deaths, and US public-health surveillance.",
+        ),
     ],
 }

--- a/bioscancast/datasets/source_tiers.py
+++ b/bioscancast/datasets/source_tiers.py
@@ -59,6 +59,36 @@ TIER_3_DOMAINS: set[str] = {
     "wikipedia.org",
     "sciencedirect.com",
     "pubmed.ncbi.nlm.nih.gov",
+    # National/international news with established newsrooms. Added after the
+    # #13 tier-coverage audit (data/investigations/findings-issues-3-4-13.md):
+    # live pools showed reputable outbreak reporting from these outlets
+    # resolving to "unknown" (domain_score 0.2), which sank them below the
+    # filter's credibility floor. Second-level-domain matching in
+    # resolve_tier() covers subdomains (edition.cnn.com, ca.news.yahoo.com,
+    # africa.businessinsider.com, etc.).
+    "cnn.com",
+    "nbcnews.com",
+    "cbsnews.com",
+    "abcnews.go.com",
+    "abcnews.com",
+    "npr.org",
+    "pbs.org",
+    "usatoday.com",
+    "latimes.com",
+    "politico.com",
+    "politico.eu",
+    "axios.com",
+    "thehill.com",
+    "forbes.com",
+    "bloomberg.com",
+    "ft.com",
+    "wsj.com",
+    "economist.com",
+    "time.com",
+    "theatlantic.com",
+    "newyorker.com",
+    "arstechnica.com",
+    "businessinsider.com",
 }
 
 TIER_4_DOMAINS: set[str] = {

--- a/bioscancast/filtering/config.py
+++ b/bioscancast/filtering/config.py
@@ -56,6 +56,18 @@ FILTER_CONFIG = {
     "auto_reject_after_rerank": 0.30,
     "max_llm_filter_candidates": 10,
 
+    # When no LLM client is configured, the ambiguous "llm_needed" band
+    # (reranked priority between auto_reject and auto_keep) is normally
+    # rejected outright (fail-closed). With this flag enabled — for dev /
+    # offline / no-API-key runs — a borderline candidate is instead KEPT if it
+    # is an official domain OR its keyword-overlap relevance clears
+    # ``no_llm_fallback_relevance_threshold``. This approximates the LLM-rescue
+    # path without an API call, recovering the on-topic / authoritative tail
+    # without admitting the generic-news mass. Default OFF so production (which
+    # always has an LLM client) is unchanged. See issue #13.
+    "no_llm_soft_fallback": False,
+    "no_llm_fallback_relevance_threshold": 0.5,
+
     "max_docs_per_domain": 2,
     "max_docs_per_type": 5,
 

--- a/bioscancast/filtering/config.py
+++ b/bioscancast/filtering/config.py
@@ -38,7 +38,14 @@ FILTER_CONFIG = {
         "domain": 0.20,
         "official_bonus": 0.20,
     },
-    "heuristic_keep_threshold": 0.72,
+    # Lowered from 0.72 to 0.65 after q7/q12 live runs showed filter
+    # survival of 4.7% / 13.5% — the threshold was tighter than the
+    # heuristic's actual signal supports. Borderline candidates that
+    # cross the new threshold still go to the LLM rescue path; this
+    # change just stops dropping high-credibility-but-low-keyword-overlap
+    # results pre-LLM (e.g. apnews/theguardian/washingtonpost in q7).
+    # See issue #13.
+    "heuristic_keep_threshold": 0.65,
     "heuristic_borderline_threshold": 0.45,
 
     "reranker_weights": {

--- a/bioscancast/filtering/heuristics.py
+++ b/bioscancast/filtering/heuristics.py
@@ -121,6 +121,27 @@ def heuristic_filter(
             )
             continue
 
+        # Dashboard-injected results are hand-curated in
+        # ``bioscancast/datasets/biosecurity_sources.py``; they bypass the
+        # keyword-overlap-driven heuristic which structurally undervalues
+        # their generic titles. See issue #14 and live-run data on q7/q12
+        # where 4/4 injected dashboards had keyword_overlap == 0.000.
+        if result.retrieval_reason == "dashboard_lookup":
+            relevance_score = compute_heuristic_relevance(result, question)
+            credibility_score = compute_heuristic_credibility(result)
+            keep_list.append(
+                make_decision(
+                    result=result,
+                    keep=True,
+                    stage="heuristic",
+                    relevance_score=relevance_score,
+                    credibility_score=credibility_score,
+                    priority_score=1.0,
+                    reason_codes=["dashboard_lookup_bypass"],
+                )
+            )
+            continue
+
         relevance_score = compute_heuristic_relevance(result, question)
         credibility_score = compute_heuristic_credibility(result)
         priority_score = compute_priority_score(result, relevance_score, credibility_score)

--- a/bioscancast/filtering/pipeline.py
+++ b/bioscancast/filtering/pipeline.py
@@ -37,11 +37,24 @@ class FilteringPipeline:
         llm_decisions: list[FilterDecision] = []
         if llm_needed:
             if self.llm_client is None:
-                # Fail closed: reject ambiguous cases if no LLM client is configured.
+                # No LLM client. Default is fail-closed (reject the ambiguous
+                # band). When the soft-fallback flag is enabled, keep candidates
+                # that are official-domain or sufficiently relevant — see
+                # FILTER_CONFIG["no_llm_soft_fallback"] and issue #13.
+                soft = FILTER_CONFIG.get("no_llm_soft_fallback", False)
+                rel_threshold = FILTER_CONFIG.get(
+                    "no_llm_fallback_relevance_threshold", 0.5
+                )
                 for d in llm_needed:
-                    d.keep = False
                     d.stage = "llm_skipped"
-                    d.reason_codes.append("no_llm_client_configured")
+                    result = result_map.get(d.result_id)
+                    is_official = bool(result and result.is_official_domain)
+                    if soft and (is_official or d.relevance_score >= rel_threshold):
+                        d.keep = True
+                        d.reason_codes.append("no_llm_soft_fallback_kept")
+                    else:
+                        d.keep = False
+                        d.reason_codes.append("no_llm_client_configured")
                 llm_decisions = llm_needed
             else:
                 llm_decisions = llm_filter_candidates(

--- a/bioscancast/filtering/postprocess.py
+++ b/bioscancast/filtering/postprocess.py
@@ -49,6 +49,17 @@ def cap_per_domain_and_type(
     max_docs_per_domain: int,
     max_docs_per_type: int,
 ) -> List[FilteredDocument]:
+    """Limit how many docs from a single domain or file type survive.
+
+    Dashboard-bypassed docs (selection_reasons contains
+    ``"dashboard_lookup_bypass"``) are always kept and do not consume a
+    slot against either cap. Curated dashboard injections are a separate
+    channel from organic search results; without this carve-out, a
+    dashboard sitting at synthetic priority 1.0 displaces a genuine
+    organic candidate on the same domain - which is exactly what
+    happened on q7 (WHO sitreps dashboard squeezed out the WHO research
+    event page that the baseline extracted records from).
+    """
     kept: list[FilteredDocument] = []
     domain_counts = defaultdict(int)
     type_counts = defaultdict(int)
@@ -56,14 +67,20 @@ def cap_per_domain_and_type(
     for doc in docs:
         doc_type = doc.file_type or "unknown"
 
-        if domain_counts[doc.domain] >= max_docs_per_domain:
-            continue
-        if type_counts[doc_type] >= max_docs_per_type:
-            continue
+        is_dashboard_bypass = "dashboard_lookup_bypass" in (
+            doc.selection_reasons or []
+        )
+
+        if not is_dashboard_bypass:
+            if domain_counts[doc.domain] >= max_docs_per_domain:
+                continue
+            if type_counts[doc_type] >= max_docs_per_type:
+                continue
 
         kept.append(doc)
-        domain_counts[doc.domain] += 1
-        type_counts[doc_type] += 1
+        if not is_dashboard_bypass:
+            domain_counts[doc.domain] += 1
+            type_counts[doc_type] += 1
 
     return kept
 

--- a/bioscancast/stages/search_stage/dashboard_lookup.py
+++ b/bioscancast/stages/search_stage/dashboard_lookup.py
@@ -48,21 +48,21 @@ def lookup_dashboards(question: ForecastQuestion) -> List[SearchResult]:
         return []
 
     pathogen_key = question.pathogen.strip().lower()
-    urls = DASHBOARD_LOOKUP.get(pathogen_key, [])
-    if not urls:
+    entries = DASHBOARD_LOOKUP.get(pathogen_key, [])
+    if not entries:
         return []
 
     as_of = question.as_of_date
     results: list[SearchResult] = []
     now = datetime.now(timezone.utc)
 
-    for url in urls:
+    for entry in entries:
         if as_of is not None:
-            snapshot = closest_snapshot_before(url, as_of)
+            snapshot = closest_snapshot_before(entry.url, as_of)
             if snapshot is None:
                 logger.info(
                     "Suppressing dashboard %s — no Wayback snapshot at-or-before %s",
-                    url, as_of.isoformat(),
+                    entry.url, as_of.isoformat(),
                 )
                 continue
             snapshot_dt, snapshot_url = snapshot
@@ -71,12 +71,12 @@ def lookup_dashboards(question: ForecastQuestion) -> List[SearchResult]:
             published_date_source = "wayback_snapshot"
             # Keep ``domain`` as the original publisher for tier scoring;
             # the URL itself points at archive.org for fetching.
-            domain = extract_domain(url)
+            domain = extract_domain(entry.url)
         else:
-            effective_url = url
+            effective_url = entry.url
             published_date = None
             published_date_source = None
-            domain = extract_domain(url)
+            domain = extract_domain(entry.url)
 
         tier_num, domain_score, source_tier = resolve_tier(domain)
 
@@ -89,8 +89,8 @@ def lookup_dashboards(question: ForecastQuestion) -> List[SearchResult]:
                 url=effective_url,
                 canonical_url=normalize_url(effective_url),
                 domain=domain,
-                title=f"Dashboard: {domain}",
-                snippet=f"Known {pathogen_key} monitoring dashboard",
+                title=entry.title,
+                snippet=entry.snippet,
                 rank=0,
                 retrieved_at=now,
                 published_date=published_date,

--- a/bioscancast/stages/search_stage/dashboard_lookup.py
+++ b/bioscancast/stages/search_stage/dashboard_lookup.py
@@ -31,6 +31,46 @@ from bioscancast.stages.search_stage.wayback import closest_snapshot_before
 logger = logging.getLogger(__name__)
 
 
+# Common name variants that should route to a canonical DASHBOARD_LOOKUP key.
+# The canonical-key substring fallback in ``_resolve_pathogen_key`` already
+# handles suffixes like "marburg virus disease" -> "marburg"; this map covers
+# synonyms where the canonical key is NOT a substring of the alias.
+_PATHOGEN_ALIASES: dict[str, str] = {
+    "monkeypox": "mpox",
+    "sars-cov-2": "covid-19",
+    "sars-cov2": "covid-19",
+    "covid": "covid-19",
+    "covid19": "covid-19",
+    "coronavirus": "covid-19",
+    "bird flu": "h5n1",
+    "avian flu": "h5n1",
+}
+
+
+def _resolve_pathogen_key(pathogen: str) -> str | None:
+    """Map a free-text pathogen string to a DASHBOARD_LOOKUP key, tolerantly.
+
+    Resolution order: exact key, exact alias, alias-substring, then
+    canonical-key substring (longest match wins, so "ebola virus disease"
+    resolves to "ebola" and "marburg virus disease" to "marburg"). Returns
+    None if nothing matches.
+    """
+    key = pathogen.strip().lower()
+    if not key:
+        return None
+    if key in DASHBOARD_LOOKUP:
+        return key
+    if key in _PATHOGEN_ALIASES and _PATHOGEN_ALIASES[key] in DASHBOARD_LOOKUP:
+        return _PATHOGEN_ALIASES[key]
+    for alias, canon in _PATHOGEN_ALIASES.items():
+        if alias in key and canon in DASHBOARD_LOOKUP:
+            return canon
+    matches = [k for k in DASHBOARD_LOOKUP if k in key]
+    if matches:
+        return max(matches, key=len)
+    return None
+
+
 def lookup_dashboards(question: ForecastQuestion) -> List[SearchResult]:
     """Generate synthetic SearchResult entries for known pathogen dashboards.
 
@@ -47,10 +87,10 @@ def lookup_dashboards(question: ForecastQuestion) -> List[SearchResult]:
     if not question.pathogen:
         return []
 
-    pathogen_key = question.pathogen.strip().lower()
-    entries = DASHBOARD_LOOKUP.get(pathogen_key, [])
-    if not entries:
+    pathogen_key = _resolve_pathogen_key(question.pathogen)
+    if not pathogen_key:
         return []
+    entries = DASHBOARD_LOOKUP[pathogen_key]
 
     as_of = question.as_of_date
     results: list[SearchResult] = []

--- a/bioscancast/stages/search_stage/pipeline.py
+++ b/bioscancast/stages/search_stage/pipeline.py
@@ -13,7 +13,9 @@ from email.utils import parsedate_to_datetime
 from typing import List, Optional
 
 from bioscancast.filtering.config import FILTER_CONFIG
+from bioscancast.filtering.heuristics import build_query_terms
 from bioscancast.filtering.models import ForecastQuestion, SearchResult
+from bioscancast.filtering.utils import keyword_overlap_score
 from bioscancast.llm.base import LLMClient
 from bioscancast.stages.search_stage.backends.base import RawSearchResult, SearchBackend
 from bioscancast.stages.search_stage.cache import SearchCache
@@ -83,10 +85,39 @@ def _compute_freshness(
     return max(0.0, min(1.0, 1.0 - (days_old / 365.0)))
 
 
-def _compute_search_stage_score(domain_score: float, freshness_score: float, rank: int) -> float:
-    """search_stage_score = 0.5 * domain_score + 0.3 * freshness_score + 0.2 * (1/rank)"""
+# search_stage_score weights (sum to 1.0). Relevance (keyword overlap of
+# title/snippet/domain against the question terms) is the dominant term:
+# domain/freshness/rank alone rank off-topic high-authority content too highly,
+# because freshness is ~uniform in live mode and domain score is too coarse to
+# separate on-topic from off-topic within a tier. Freshness is kept low for that
+# reason. See data/investigations/findings-issues-3-4-13.md (#4).
+_SCORE_W_RELEVANCE = 0.45
+_SCORE_W_DOMAIN = 0.30
+_SCORE_W_FRESHNESS = 0.10
+_SCORE_W_RANK = 0.15
+
+
+def _compute_relevance(result: SearchResult, question: ForecastQuestion) -> float:
+    """Keyword overlap of the result against the question terms.
+
+    Mirrors ``bioscancast.filtering.heuristics.compute_heuristic_relevance`` so
+    the search stage and the filter stage use the same relevance signal.
+    """
+    text = f"{result.title} {result.snippet} {result.domain}"
+    return keyword_overlap_score(text, build_query_terms(question))
+
+
+def _compute_search_stage_score(
+    relevance: float, domain_score: float, freshness_score: float, rank: int
+) -> float:
+    """search_stage_score = 0.45*relevance + 0.30*domain + 0.10*freshness + 0.15*(1/rank)"""
     rank_score = 1.0 / max(rank, 1)
-    raw = 0.5 * domain_score + 0.3 * freshness_score + 0.2 * rank_score
+    raw = (
+        _SCORE_W_RELEVANCE * relevance
+        + _SCORE_W_DOMAIN * domain_score
+        + _SCORE_W_FRESHNESS * freshness_score
+        + _SCORE_W_RANK * rank_score
+    )
     return max(0.0, min(1.0, raw))
 
 
@@ -260,7 +291,10 @@ class SearchStagePipeline:
                 r.published_date, reference_date=as_of
             )
             r.search_stage_score = _compute_search_stage_score(
-                r.domain_score, r.freshness_score, r.rank
+                _compute_relevance(r, question),
+                r.domain_score,
+                r.freshness_score,
+                r.rank,
             )
 
         # 8. Sort and cap

--- a/bioscancast/tests/test_dashboard_lookup.py
+++ b/bioscancast/tests/test_dashboard_lookup.py
@@ -46,6 +46,23 @@ class TestDashboardLookup:
         results = lookup_dashboards(q)
         assert len(results) > 0
 
+    def test_multiword_pathogen_routes_via_substring(self):
+        # CSV-natural "Marburg Virus Disease" -> pathogen "marburg virus disease"
+        # must still route to the "marburg" dashboard key.
+        canonical = lookup_dashboards(_make_question(pathogen="marburg"))
+        multiword = lookup_dashboards(_make_question(pathogen="marburg virus disease"))
+        assert len(multiword) > 0
+        assert [r.url for r in multiword] == [r.url for r in canonical]
+
+    def test_alias_routes_to_canonical(self):
+        # "monkeypox" -> "mpox"; "bird flu" -> "h5n1".
+        assert len(lookup_dashboards(_make_question(pathogen="monkeypox"))) > 0
+        assert (
+            [r.url for r in lookup_dashboards(_make_question(pathogen="monkeypox"))]
+            == [r.url for r in lookup_dashboards(_make_question(pathogen="mpox"))]
+        )
+        assert len(lookup_dashboards(_make_question(pathogen="bird flu"))) > 0
+
     def test_results_have_required_fields(self):
         q = _make_question(pathogen="ebola")
         results = lookup_dashboards(q)

--- a/bioscancast/tests/test_pipeline.py
+++ b/bioscancast/tests/test_pipeline.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 
+from bioscancast.filtering.config import FILTER_CONFIG
 from bioscancast.filtering.models import ForecastQuestion, SearchResult
 from bioscancast.filtering.pipeline import FilteringPipeline
 
@@ -37,3 +38,58 @@ def test_pipeline_keeps_official_result():
 
     assert len(docs) == 1
     assert docs[0].domain == "who.int"
+
+
+def _borderline_question():
+    return ForecastQuestion(
+        id="q1",
+        text="How many confirmed Ebola cases in the DRC outbreak?",
+        created_at=datetime(2026, 5, 1),
+        pathogen="ebola",
+        region="DRC",
+    )
+
+
+def _borderline_result():
+    # trusted_media (domain_score 0.6, non-official) with partial term overlap →
+    # lands in the heuristic borderline band, then the no-LLM "llm_needed" band.
+    return SearchResult(
+        id="r-border",
+        question_id="q1",
+        query_id="sq1",
+        engine="google",
+        url="https://www.cnn.com/ebola-drc",
+        canonical_url="https://www.cnn.com/ebola-drc",
+        domain="cnn.com",
+        title="Ebola cases climb in the DRC outbreak",
+        snippet="Confirmed Ebola cases reported in the Democratic Republic of the Congo outbreak.",
+        rank=2,
+        retrieved_at=datetime(2026, 5, 1),
+        source_tier="trusted_media",
+        is_official_domain=False,
+        domain_score=0.6,
+        freshness_score=1.0,
+        search_stage_score=0.6,
+    )
+
+
+def test_no_llm_soft_fallback_flag_changes_borderline_outcome():
+    question = _borderline_question()
+    result = _borderline_result()
+
+    saved = dict(FILTER_CONFIG)
+    try:
+        # Flag OFF (default): fail closed → borderline candidate dropped.
+        FILTER_CONFIG["no_llm_soft_fallback"] = False
+        docs_off = FilteringPipeline(llm_client=None).run(question, [result])
+
+        # Flag ON: relevant borderline candidate kept without an LLM call.
+        FILTER_CONFIG["no_llm_soft_fallback"] = True
+        FILTER_CONFIG["no_llm_fallback_relevance_threshold"] = 0.0
+        docs_on = FilteringPipeline(llm_client=None).run(question, [result])
+    finally:
+        FILTER_CONFIG.clear()
+        FILTER_CONFIG.update(saved)
+
+    assert {d.result_id for d in docs_off} == set()
+    assert {d.result_id for d in docs_on} == {"r-border"}

--- a/bioscancast/tests/test_search_pipeline.py
+++ b/bioscancast/tests/test_search_pipeline.py
@@ -160,9 +160,14 @@ class TestSearchStagePipeline:
 
     def test_scoring_formula(self):
         """Verify the search_stage_score formula for a known result."""
+        from bioscancast.stages.search_stage.pipeline import _compute_relevance
+
+        question = _make_question()
         results = self._run_pipeline()
         for r in results:
-            expected = 0.5 * r.domain_score + 0.3 * r.freshness_score + 0.2 * (1.0 / max(r.rank, 1))
+            rel = _compute_relevance(r, question)
+            rank_score = 1.0 / max(r.rank, 1)
+            expected = 0.45 * rel + 0.30 * r.domain_score + 0.10 * r.freshness_score + 0.15 * rank_score
             expected = max(0.0, min(1.0, expected))
             assert abs(r.search_stage_score - expected) < 1e-9, (
                 f"Score mismatch for {r.url}: {r.search_stage_score} != {expected}"

--- a/bioscancast/tests/test_tier_resolution.py
+++ b/bioscancast/tests/test_tier_resolution.py
@@ -54,6 +54,18 @@ class TestResolveTier:
         assert score == 0.2
         assert label == "unknown"
 
+    def test_national_news_is_trusted_media(self):
+        for domain in ("cnn.com", "nbcnews.com", "forbes.com", "latimes.com", "npr.org"):
+            tier, score, label = resolve_tier(domain)
+            assert tier == 3, domain
+            assert score == 0.6, domain
+            assert label == "trusted_media", domain
+
+    def test_national_news_subdomain_match(self):
+        # edition.cnn.com / africa.businessinsider.com resolve via SLD.
+        assert resolve_tier("edition.cnn.com")[2] == "trusted_media"
+        assert resolve_tier("africa.businessinsider.com")[2] == "trusted_media"
+
     def test_subdomain_match(self):
         """wwwnc.cdc.gov should match cdc.gov via second-level domain."""
         tier, score, label = resolve_tier("wwwnc.cdc.gov")

--- a/data/investigations/findings-issues-3-4-13.md
+++ b/data/investigations/findings-issues-3-4-13.md
@@ -1,0 +1,238 @@
+# Systematic review of issues #3, #4, #13 — findings
+
+Date: 2026-05-28 · Branch: `feat/end-to-end-orchestrator`
+
+## Method
+
+- Drafted 10 live forecasting questions (`data/investigations/live_questions.csv`,
+  `L1`–`L10`) mirroring the `bioscancast_questions.csv` schema, spanning
+  range/binary/categorical across H5N1, the DRC+Uganda Bundibugyo Ebola
+  outbreak, the Andes-virus cruise hantavirus cluster, mpox, and Marburg.
+  Topics chosen to span dashboard-covered vs not.
+- **Captured** the live search pool for each (`scripts/capture_search_pools.py`
+  → `data/investigations/live_pools/<id>.json`). `total_cap=60`; all pools were
+  29–49 results, so **none were truncated** — the captured pools are complete.
+- **Hand-labeled** every result keep/drop (`live_pools/labels.json`).
+- **Swept** filter thresholds (#13) and search-stage weights (#4) offline and
+  deterministically over the cached pools (`scripts/sweep_filter_params.py`),
+  scored against the labels. Zero API cost.
+- **Ran the full pipeline live** end-to-end on 5 questions + 1 historical replay
+  (`data/investigations/runs/`).
+
+**Cost:** total ≈ **$0.025** across all 6 live/replay runs (well under the $5
+cap). The offline sweep and dashboard checks were free.
+
+## Headline finding (ties all three issues together)
+
+`search_stage_score = 0.5·domain + 0.3·freshness + 0.2·(1/rank)` contains **no
+relevance/topic-match term**. Combined with Tavily's recency bias, this means
+that whenever the question's pathogen is *not* the dominant news story of the
+moment, the organic pool is flooded with off-topic high-authority content that
+ranks well on domain score alone.
+
+In our snapshot (late May 2026) Ebola was *the* story, so:
+
+| Question | On-topic organic results | Dominant noise in pool |
+|----------|--------------------------|------------------------|
+| L1/L2 H5N1 | ~0 (only the 2 dashboards) | Ebola/hantavirus/measles news, a nature.com TB paper at rank 0, Law360, Ukraine casualties, a King Charles death hoax |
+| L7/L8 mpox | ~1 organic (fox6now WI cluster) + dashboards | Ebola + NHL/FIFA/NCAA/Belmont/French-Open picks, nature.com (nuclear-fuel cladding, semaglutide), biospace PR |
+| L9 Marburg | ~0 (only the 2 dashboards) | entirely the Ebola/hantavirus roundup |
+| L3/L4 Ebola | rich, genuine coverage | minimal |
+
+No amount of filter-threshold tuning (#13) can recover relevance that the
+search stage never surfaced. The dashboards (#3) are the only thing keeping the
+off-peak questions afloat — but, per below, they frequently don't extract.
+
+## Issue #4 — search-stage weights
+
+**The weights barely matter; the missing dimension does.** On organic-ranking
+quality (precision@P / MAP, micro-averaged, scored vs labels):
+
+| Variant (domain/fresh/rank[/rel]) | prec@P | MAP |
+|---|---|---|
+| current 0.5/0.3/0.2 | 0.694 | 0.506 |
+| no-freshness 0.6/0/0.4 | 0.694 | 0.528 |
+| rank-heavy 0.4/0.1/0.5 | 0.694 | 0.580 |
+| domain-heavy 0.7/0.1/0.2 | 0.694 | 0.506 |
+| **+relevance 0.25/0.15/0.1/0.5** | 0.725 | 0.600 |
+| **relevance-only 0/0/0/1** | **0.755** | **0.656** |
+
+- Reordering domain/freshness/rank leaves top-P precision **unchanged** (0.694)
+  — freshness is ~uniform (≈0.98–1.0) in live mode so its 0.3 weight is nearly
+  dead signal, and domain score is too coarse to separate on-topic from
+  off-topic within a tier.
+- Adding a keyword-overlap **relevance** term is the only thing that moves the
+  needle: MAP 0.506 → 0.656.
+
+**Recommendation (#4):** add a relevance/keyword-overlap term to
+`_compute_search_stage_score` (the same `keyword_overlap_score` the filter
+already uses), e.g. `0.35·relevance + 0.30·domain + 0.10·freshness +
+0.10·rank` (drop freshness's weight; it is near-useless live). Keep `rank` low.
+This is the highest-leverage change of the three issues and prevents off-topic
+authority from consuming the `total_cap` slots.
+
+## Issue #13 — heuristic filter survival
+
+**The keep threshold sits on a wide plateau; it is not the lever.** Organic-only,
+micro-averaged, no-LLM (fail-closed) sweep:
+
+| keep_threshold | precision | recall | organic survivors | official recall |
+|---|---|---|---|---|
+| 0.50 | 0.43 | 0.20 | 47 | 1.0 |
+| 0.575 | 0.23 | 0.03 | 13 | 1.0 |
+| **0.60 – 0.775** | **0.43–0.50** | **0.03** | **6 (flat)** | **1.0** |
+| 0.80 | 0.60 | 0.03 | 5 | 1.0 |
+
+- Thresholds **0.60 through 0.775 are identical** (6 survivors). The
+  `0.72 → 0.65` change (commit `f63684b`) moved within this flat region — it
+  did not, by itself, change organic survival. (It still matters as the cutoff
+  below which the LLM-rescue path is fed; see below.)
+- **Official-source recall is 1.0 at every threshold** — the ECDC/official
+  organic sources we labeled keep always survive. The fix for the original
+  "dropping CDC/WHO" symptom is holding.
+- The two real recall sinks are structural, not the threshold:
+  1. **Fail-closed LLM path.** 84 organic candidates land in the rerank→LLM
+     band; with `llm_client=None` *all 84 are dropped*. This is by far the
+     dominant dev-mode recall sink.
+  2. **Unknown-tier credibility floor.** Much legitimate outbreak news
+     (Forbes, LA Times, NBC) resolves to `source_tier="unknown"`
+     (`domain_score=0.20`, `credibility≈0.35`). `priority_score` blends in
+     `0.25·credibility`, which caps these below the 0.45 borderline regardless
+     of keyword overlap, so they are rejected outright (278 of 379 organic).
+     Aggressively reweighting toward keyword-overlap and lowering the borderline
+     barely helped (recall 0.03 → 0.05) — the credibility floor and tier
+     mis-classification dominate.
+
+**Caveat on the metric:** our labels generously marked ~190 mostly-redundant
+on-topic news items as keep, so absolute *recall* understates filter quality
+(dedup/cap would collapse that tail anyway). **Precision (~0.5) and official
+recall (1.0)** are the trustworthy numbers; precision ~0.5 means roughly half of
+kept organic results are still off-topic — a real problem that the #4 relevance
+term would address upstream.
+
+**Recommendations (#13):**
+- Keep `heuristic_keep_threshold` at **0.60–0.65** (anywhere in the plateau is
+  equivalent); stop treating it as a tunable — it isn't, on this data.
+- The bigger wins are upstream (#4 relevance term) and in **tier coverage**:
+  promote major wire/national outlets out of `unknown` so their `domain_score`
+  isn't a hard ceiling. Consider lowering the `0.25·credibility` blend weight in
+  `compute_priority_score`.
+- **Fail-closed fallback (the deferred decision):** the data now supports a
+  decision. 84 organic candidates hit the band, but precision is already ~0.5,
+  so a blanket "auto-keep all borderline ≥0.60" would push precision lower.
+  Recommend a **targeted** soft fallback instead: when `llm_client=None`,
+  auto-keep a borderline candidate only if it is `is_official_domain` **or**
+  has high keyword-overlap relevance — recovering the on-topic tail without
+  admitting the generic-news mass. Gate it behind a config flag so production
+  (which has an LLM) is unchanged.
+
+## Issue #3 — dashboard value vs organic search
+
+**Dashboards are essential for off-peak pathogens but their value is bimodal at
+extraction time.** End-to-end live runs:
+
+| Q | pathogen | survivors | of which dashboard | insight records | note |
+|---|---|---|---|---|---|
+| L1 | H5N1 | 2 | 2 | 1 | CDC bird-flu *situation-summary* extracts (some content) |
+| L3 | Ebola | 7 | 2 | 11 | rich organic; guard dropped 1 fabricated quote |
+| L5 | hantavirus | 2 | 0 | 5 | organic-only (apnews+wapo) → good cruise-cluster facts |
+| L7 | mpox | 3 | 3 | **0** | all 3 dashboards non-extractable (see below) |
+| L9 | Marburg | 7 | 2 | 43 | WHO Marburg *factsheet* → many (historical) records |
+
+- **Dashboards crowd out organic and then yield nothing when the URL is an
+  interactive tracker / index / landing page.** L7 mpox is the worst case: the 3
+  injected dashboards (`who.int/.../situation-reports` index,
+  `cdc.gov/mpox/data-research` [a **404**], `ourworldindata.org/mpox`
+  [JS viz]) extracted as 245/456/2358-char shells and produced **0 records** —
+  while the one organic result with real mpox case data (fox6now Wisconsin
+  cluster) was filtered out. The pipeline produced nothing usable for mpox.
+- **Static fact-bearing dashboards do work**: the WHO Marburg factsheet (L9) and
+  CDC bird-flu situation summary (L1) are prose pages and yielded records.
+- **Staleness check** (all 11 URLs in `biosecurity_sources.py`):
+  - **Broken:** `cdc.gov/mpox/data-research/index.html` → **404** (redirects to
+    `monkeypox/...` which is also dead).
+  - **Stale redirects (update to canonical):**
+    `afro.who.int/health-topics/ebola-virus-disease` → `…/ebola-disease`;
+    `cdc.gov/ebola/index.html` → `cdc.gov/ebola/about/index.html`.
+  - Other 8 return 200.
+- **Routing brittleness:** `DASHBOARD_LOOKUP` is matched by **exact** lowercased
+  `pathogen` key. The CSV-natural topic "Marburg Virus Disease" yields
+  `pathogen="marburg virus disease"`, which does **not** match the `marburg`
+  key — L9 would have gotten **zero** on-topic results (we had to rename the
+  topic to "Marburg" to make it route). Same risk for any multi-word pathogen.
+
+**Recommendations (#3):**
+- **Fix the broken/stale URLs** above. Prefer static, fact-bearing pages over
+  interactive viz where possible: e.g. point mpox at a WHO mpox external
+  situation-report landing or the OWID *data* endpoint, not the JS tracker.
+- **Make routing tolerant** — substring/alias match (`"marburg" in pathogen`) or
+  a normalization map, so multi-word pathogen names still route.
+- **Re-evaluate the "extract dashboards as documents" assumption.** For
+  interactive trackers the current value at the insight stage is ~0; either
+  (a) attach a curated structured snapshot/PDF per dashboard, or (b) treat
+  dashboards as resolution-source pointers rather than extractable documents,
+  and don't let them consume `total_cap`/survival slots that organic
+  fact-bearing sources need.
+- Keep dashboards for **off-peak pathogens** (H5N1, mpox, Marburg) where they
+  are the only on-topic authority; their problem is extractability, not
+  relevance.
+
+## Historical-replay confound (confirmed)
+
+`q7` (mpox, resolved) replayed at cutoff 2025-02-17 survived 5 docs = 2
+wayback-rewritten dashboards + 3 organic, but the 3 organic were **2024
+preparedness/calendar pages** (whitehouse.gov, WHO event pages), not case-count
+data → 1 insight record. This confirms `specs/tavily-historical-coverage.md`:
+replay survival is dashboard/official-dominated with little fresh outbreak
+signal, so **forecast-accuracy on resolved questions cannot drive filter/weight
+tuning** — which is why we tuned against hand labels on live pools instead.
+
+## Limitations
+
+- Single point-in-time snapshot (late May 2026, Ebola-dominant). The relevance
+  collapse for off-peak pathogens may be milder in a quieter news period.
+- Labels are one annotator's judgment; gray-zone calls (opinion vs reportage,
+  redundant news) affect absolute recall more than the qualitative conclusions.
+- #4 truncation effect is not exercised here (pools < `total_cap`); the relevance
+  term's benefit would be *larger* when pools exceed the cap.
+
+## Suggested next actions (not done in this pass)
+
+1. (#4) Add a relevance term to `_compute_search_stage_score` + unit test.
+2. (#3) Fix the 1 broken + 2 stale dashboard URLs; make `DASHBOARD_LOOKUP`
+   routing substring/alias-tolerant.
+3. (#13) Implement the targeted `llm_client=None` soft fallback behind a flag.
+4. (#13) Audit `tier_resolution` coverage so major wire/national outlets aren't
+   `unknown`.
+
+## Changes implemented (follow-up pass)
+
+- **#4** — `_compute_search_stage_score` now includes a keyword-overlap
+  relevance term (`0.45·relevance + 0.30·domain + 0.10·freshness + 0.15·rank`,
+  sums to 1.0), reusing the filter's `keyword_overlap_score`/`build_query_terms`.
+  Relevance is the dominant term; freshness kept low (near-uniform live).
+- **#3** — fixed the broken CDC mpox URL (now the extractable
+  `monkeypox/situation-summary` page; re-run yielded **2 records vs 0**), the
+  two stale redirects (afro.who.int ebola-disease, cdc.gov/ebola/about), and
+  made `DASHBOARD_LOOKUP` routing substring/alias-tolerant (`_resolve_pathogen_key`)
+  so "marburg virus disease"→marburg, "monkeypox"→mpox, "bird flu"→h5n1.
+- **#13 (tier coverage)** — added ~22 national/international outlets
+  (CNN, NBC, CBS, ABC, NPR, USA Today, LA Times, Politico, Axios, Forbes,
+  Bloomberg, FT, WSJ, Economist, Time, Atlantic, Ars Technica, Business Insider,
+  …) to Tier 3 (`trusted_media`, domain_score 0.6) so legitimate outbreak
+  reporting is no longer floored at `unknown`/0.2. Validation note: this raises
+  recall of reputable reporting but, because the *filter's* `priority_score`
+  still weights credibility heavily, it can also admit off-topic pieces from
+  those outlets (e.g. an H5N1 run kept a CBS transcript) — the search-stage
+  relevance term does not feed the filter's keep decision. Worth considering
+  raising the filter's keyword-overlap weight / lowering its `0.25·credibility`
+  blend as a follow-up.
+- **#13 fail-closed fallback** — implemented option **C (targeted soft-keep)**
+  behind a default-off flag `FILTER_CONFIG["no_llm_soft_fallback"]`
+  (+ `no_llm_fallback_relevance_threshold`, default 0.5). When enabled and no LLM
+  client is configured, a borderline ("llm_needed") candidate is kept iff it is
+  an official domain OR its keyword-overlap relevance clears the threshold —
+  approximating the LLM-rescue path for dev/offline runs. Default off, so
+  production (always has an LLM client) is unchanged.
+- All 455 tests pass; new tests added for the score formula, tolerant routing,
+  tier coverage, and the soft-fallback flag.


### PR DESCRIPTION
# Search/filter dashboard chokepoint + relevance ranking

> Split from the original `feat/end-to-end-orchestrator` branch (was #28).
> Companion PRs: **#29** (orchestrator) and **#31** (insight extraction
> quality). All three are independent and can merge in any order.

## Summary

A bundle of search-stage and filter-stage improvements driven by a systematic
review of 10 live forecasting questions (H5N1, the 2026 DRC+Uganda Ebola
outbreak, the Andes-virus cruise hantavirus cluster, mpox, Marburg) spanning
range/binary/categorical, plus a deterministic offline sweep of filter
thresholds and search-stage weights against hand-labeled live pools. Findings
file (`data/investigations/findings-issues-3-4-13.md`) carries the full method
and numbers — most of the relevant tables are surfaced below. Total API spend
across all the live runs that produced this branch: ~$0.05.

Addresses issues #3, #4, #13, #14.

## What's included

### Filter chokepoint (#13, #14)

- **Dashboard-injected results bypass the keyword-overlap heuristic**
  (`retrieval_reason == "dashboard_lookup"`) — they were getting
  `keyword_overlap_score == 0.000` and being dropped despite being curated
  authoritative sources.
- **Dashboard titles/snippets enriched with pathogen-specific text** in
  `biosecurity_sources.py` (was "Dashboard: cdc.gov" / "Known mpox monitoring
  dashboard"; now real readable titles+snippets per entry).
- **`heuristic_keep_threshold` lowered 0.72 → 0.65**. Note (from the sweep)
  the threshold sits on a flat plateau 0.60–0.775 — see the #13 finding.
- **Dashboard-bypass docs exempted from `cap_per_domain_and_type`** so a
  curated dashboard doesn't displace an organic result on the same domain.

### Search-stage relevance ranking (#4)

`search_stage_score` was `0.5·domain + 0.3·freshness + 0.2·(1/rank)` — **no
topical-relevance term**, so high-authority but off-topic results ranked at
the top and consumed `total_cap` slots. It now is

```
0.45·relevance + 0.30·domain + 0.10·freshness + 0.15·(1/rank)
```

where `relevance` reuses the filter's existing `keyword_overlap_score` /
`build_query_terms`. Freshness is weighted low because it is near-uniform in
live mode. Weights sum to 1.0; the score drives ranking + truncation only.

**Sweep numbers** (micro-averaged precision@P / MAP, scored vs labels):

| Variant (domain/fresh/rank[/rel]) | prec@P | MAP |
|---|---|---|
| current 0.5/0.3/0.2 | 0.694 | 0.506 |
| no-freshness 0.6/0/0.4 | 0.694 | 0.528 |
| rank-heavy 0.4/0.1/0.5 | 0.694 | 0.580 |
| domain-heavy 0.7/0.1/0.2 | 0.694 | 0.506 |
| **+relevance 0.25/0.15/0.1/0.5** | 0.725 | 0.600 |
| **relevance-only** | **0.755** | **0.656** |

Reordering domain/freshness/rank leaves precision@P flat at 0.694; adding a
relevance term is the only thing that moves the needle.

### Dashboard sources (#3)

- Fixed a **broken** dashboard URL (`cdc.gov/mpox/data-research` → 404; now
  the extractable `monkeypox/situation-summary` page — re-running mpox after
  the URL fix went **0 → 2 insight records**) and two stale redirects
  (`afro.who.int` ebola-disease, `cdc.gov/ebola/about`).
- `DASHBOARD_LOOKUP` routing was an exact lowercase-key match, so the
  CSV-natural "marburg virus disease" failed to route to the `marburg` key
  (→ zero on-topic results). Added `_resolve_pathogen_key` with alias +
  substring matching (`marburg virus disease`→marburg, `monkeypox`→mpox,
  `bird flu`→h5n1).

### Source tiers (#13)

- Promoted ~22 national/international outlets (CNN, NBC, CBS, ABC, NPR, USA
  Today, LA Times, Politico, Axios, Forbes, Bloomberg, FT, WSJ, Economist,
  Time, The Atlantic, Ars Technica, Business Insider, …) from `unknown` (0.2)
  to Tier 3 `trusted_media` (0.6). Legitimate outbreak reporting from these
  was being floored below the filter's credibility threshold.

### No-LLM filter fallback (#13)

- Default-off `FILTER_CONFIG["no_llm_soft_fallback"]` (+
  `no_llm_fallback_relevance_threshold`). When `llm_client is None`, the
  ambiguous rerank band was always rejected (fail-closed) — too aggressive
  for dev/offline/no-API-key runs. With the flag on, a borderline candidate
  is kept iff it is an official domain OR clears the relevance threshold,
  approximating the LLM-rescue path. Production (always has an LLM client)
  is unchanged.

## Known interaction to flag for reviewers

Promoting outlets to Tier 3 raises recall of legitimate reporting, but
because the *filter's* `priority_score` still weights credibility heavily
(and the new relevance term lives in *search* ranking, not the filter's keep
decision), it can also admit off-topic pieces from those same outlets (an
H5N1 run kept a CBS transcript). A sensible follow-up is to raise the
filter's keyword-overlap weight / lower its `0.25·credibility` blend — that's
**not** in this PR.

## Issues this PR addresses

- **Closes #14** — dashboard low-keyword-overlap problem fixed at the root
  (titles) and as a backstop (bypass + cap exemption).
- **#4** (search-stage weight tuning) — **addressed**: added the relevance
  term and retuned weights; the follow-up review showed the missing relevance
  signal, not the weight split, was the issue. Reviewers can likely close.
- **#3** (dashboard value vs organic) — **substantially addressed**: evaluated
  value (bimodal extractability finding), fixed the broken/stale URLs, and
  made routing tolerant. One follow-up remains: deciding whether
  non-extractable interactive dashboards should consume survival slots (and
  trimming/expanding the list accordingly).
- **#13** (heuristic scores too low) — **materially improved** (threshold +
  bypass + cap exemption + tier coverage + opt-in no-LLM soft fallback). The
  review also showed the 0.65 threshold is on a flat plateau (not the lever)
  and that the filter's credibility-vs-relevance balance is the remaining
  knob — see the follow-up section. Reviewers decide whether the original
  bug is resolved.

## Verification

- `python -m pytest bioscancast/tests/` — **452 passed, 2 skipped** (live).
  New tests cover the relevance scoring formula, tolerant dashboard routing,
  Tier 3 outlet coverage, and the no-LLM soft-fallback flag.
- Live runs of q7 (historical replay) and q12 (live) end-to-end producing
  artifacts inspected for filter survival, records, and cost.
- Follow-up: 10 fresh live questions + hand-labeled offline sweep — see
  `data/investigations/findings-issues-3-4-13.md`. Re-running mpox after the
  dashboard URL fix went from 0 → 2 insight records.

## Reviewer checklist

- [ ] Confirm the dashboard cap-exemption policy in
  `cap_per_domain_and_type` (curated dashboards never consume a domain slot).
- [ ] Sanity-check the Tier 3 outlet additions in `source_tiers.py` and the
  credibility-vs-relevance interaction noted above.
- [ ] Note the 0.65 keep threshold is unchanged and now known to sit on a
  flat plateau (a sweep was done — it's not the lever).
