### PR TITLE
OWID scrapers: report cumulative totals + restore COVID (closes #38, addresses #34)

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,21 +172,20 @@ Intended responsibilities:
 ```text
 bioscancast/
 ├── bioscancast/
-│   ├── datasets/      Source registries and tier definitions
-│   ├── extraction/    Fetching, parsing, and chunking
-│   ├── filtering/     Relevance filtering and reranking
-│   ├── insight/       Retrieval and insight extraction
-│   ├── llm/           LLM client abstractions
-│   ├── schemas/       Shared data models
+│   ├── datasets/        Source registries and tier definitions
+│   ├── llm/             LLM client abstractions
+│   ├── orchestration/   End-to-end run orchestration and persistence
+│   ├── schemas/         Shared data models
 │   ├── stages/
-│   │   ├── searching/
-│   │   └── evaluation/
-│   └── tests/         Unit and integration tests
+│   │   ├── searching/   Search stage
+│   │   ├── filtering/   Filtering stage
+│   │   ├── extraction/  Extraction stage
+│   │   ├── insight/     Insight stage
+│   │   └── evaluation/  Evaluation tooling
+│   └── tests/           Unit and integration tests
 ├── data/
-│   ├── raw/
-│   ├── processed/
-│   └── docling_eval/
-├── evaluation/
+│   ├── docling_eval/
+│   └── investigations/
 ├── scripts/
 ├── pyproject.toml
 ├── requirements.txt
@@ -197,16 +196,17 @@ bioscancast/
 
 # Core Modules
 
-| Module                 | Purpose                                    |
-| ---------------------- | ------------------------------------------ |
-| `datasets/`            | curated source registries and source tiers |
-| `extraction/`          | fetching, parsing, chunking                |
-| `filtering/`           | source filtering and ranking               |
-| `insight/`             | retrieval and fact extraction              |
-| `llm/`                 | model abstractions                         |
-| `schemas/`             | shared structured contracts                |
-| `stages/searching/`    | retrieval stage                            |
-| `stages/evaluation/`   | evaluation tooling                         |
+| Module                 | Purpose                                     |
+| ---------------------- | ------------------------------------------- |
+| `datasets/`            | curated source registries and source tiers  |
+| `llm/`                 | model abstractions                          |
+| `orchestration/`       | end-to-end run orchestration + persistence  |
+| `schemas/`             | shared structured contracts                 |
+| `stages/searching/`    | retrieval stage                             |
+| `stages/filtering/`    | source filtering and ranking                |
+| `stages/extraction/`   | fetching, parsing, chunking                 |
+| `stages/insight/`      | retrieval and fact extraction               |
+| `stages/evaluation/`   | evaluation tooling                          |
 
 ---
 
@@ -248,7 +248,7 @@ Known limitations:
 ## Filtering Stage
 
 ```text
-bioscancast/filtering/
+bioscancast/stages/filtering/
 ```
 
 Implemented modules:
@@ -275,7 +275,7 @@ Current features:
 ## Extraction Stage
 
 ```text
-bioscancast/extraction/
+bioscancast/stages/extraction/
 ```
 
 Implemented modules:
@@ -331,7 +331,7 @@ Current limitations:
 ## Insight Stage
 
 ```text
-bioscancast/insight/
+bioscancast/stages/insight/
 ```
 
 Implemented modules:
@@ -342,7 +342,7 @@ Implemented modules:
 | `retrieval/bm25.py`             | lexical retrieval   |
 | `retrieval/embeddings.py`       | embedding retrieval |
 | `retrieval/hybrid.py`           | hybrid reranking    |
-| `extraction/chunk_extractor.py` | fact extraction     |
+| `text_extraction/chunk_extractor.py` | fact extraction |
 
 Current features:
 
@@ -400,7 +400,7 @@ Key schemas:
 Additional filtering models live in:
 
 ```text
-bioscancast/filtering/models.py
+bioscancast/stages/filtering/models.py
 ```
 
 including:
@@ -687,7 +687,7 @@ Important dependencies:
 `curl_cffi` is used in:
 
 ```text
-bioscancast/extraction/fetcher.py
+bioscancast/stages/extraction/fetcher.py
 ```
 
 The impersonation profile is configurable via:

--- a/README.md
+++ b/README.md
@@ -179,8 +179,8 @@ bioscancast/
 │   ├── llm/           LLM client abstractions
 │   ├── schemas/       Shared data models
 │   ├── stages/
-│   │   ├── search_stage/
-│   │   └── eval_stage/
+│   │   ├── searching/
+│   │   └── evaluation/
 │   └── tests/         Unit and integration tests
 ├── data/
 │   ├── raw/
@@ -205,8 +205,8 @@ bioscancast/
 | `insight/`             | retrieval and fact extraction              |
 | `llm/`                 | model abstractions                         |
 | `schemas/`             | shared structured contracts                |
-| `stages/search_stage/` | retrieval stage                            |
-| `stages/eval_stage/`   | evaluation tooling                         |
+| `stages/searching/`    | retrieval stage                            |
+| `stages/evaluation/`   | evaluation tooling                         |
 
 ---
 
@@ -215,7 +215,7 @@ bioscancast/
 ## Search Stage
 
 ```text
-bioscancast/stages/search_stage/
+bioscancast/stages/searching/
 ```
 
 Implemented modules:
@@ -360,7 +360,7 @@ Current features:
 # Evaluation
 
 ```text
-bioscancast/stages/eval_stage/
+bioscancast/stages/evaluation/
 ```
 
 Implemented modules:
@@ -462,7 +462,7 @@ predict. Turn it on for the benchmark and off for production.
 What this mode does NOT fix: the LLMs themselves were trained on data that
 postdates many of our benchmark questions. Retrieval fairness ≠ model
 fairness. The `retrieval_free_baseline_forecast` metric in
-`bioscancast/stages/eval_stage/contamination.py` reports how well the LLM
+`bioscancast/stages/evaluation/contamination.py` reports how well the LLM
 forecasts with no evidence at all; a small gap between that and the full
 pipeline is itself evidence of training-data leakage and must be reported
 alongside the headline Brier/log scores.
@@ -543,7 +543,7 @@ TAVILY_API_KEY=tvly-...
 ## Search Stage
 
 ```bash
-python scripts/run_search_stage.py \
+python scripts/run_searching.py \
   "Will H5N1 cause more than 100 human cases in the US by December 2026?" \
   --pathogen h5n1 \
   --region "United States"

--- a/bioscancast/stages/extraction/custom_scrapers/_owid_common.py
+++ b/bioscancast/stages/extraction/custom_scrapers/_owid_common.py
@@ -1,0 +1,385 @@
+"""Shared Our World in Data CSV scraper core (issues #34 / #38).
+
+OWID topic pages (``ourworldindata.org/mpox``, ``/coronavirus``) render their
+charts client-side, so a static scrape captures only prose + a citations list —
+no case numbers (issue #34). OWID also publishes the underlying data as plain
+CSV time series (canonically on GitHub raw), carrying the full daily history
+with ``location`` and ``date`` columns plus **cumulative** ``total_cases`` /
+``total_deaths``. We fetch that instead, select the target entity, apply the
+as-of cutoff as a row filter, and render a compact HTML summary the existing
+HTML extraction pipeline consumes unchanged.
+
+This module holds the logic shared by every OWID dataset. Each dataset gets a
+thin ``custom_scrapers/<source_id>.py`` module (matching its ``sources.yaml``
+id) that defines an :class:`OWIDDataset` and delegates to :func:`fetch_owid`.
+
+Why cumulative, not 7-day incidence: the benchmark mpox questions (q7/q8)
+resolve on cumulative counts (~130,000). The earlier explorer endpoint
+(``Metric=Confirmed cases&Frequency=7-day average``) returns only
+``new_cases_smoothed`` — a ~2-digit daily incidence number — which is
+confidently wrong for a cumulative question (issue #38, finding 1). We surface
+``total_cases`` / ``total_deaths`` explicitly rather than guessing the column.
+
+Caveat (carried from #34): OWID revises historical values over time, so a
+replay uses *today's CSV's* estimate of the cutoff-date value, not the value as
+published on that date. That is a far smaller error than the zero-record
+fallback it replaces, and is exactly correct for live forecasting. See
+``data/investigations/issue-34-owid-dashboard-fetch.md``.
+"""
+
+from __future__ import annotations
+
+import csv
+import html
+import io
+import logging
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Callable, Optional
+
+from bioscancast.stages.extraction.config import ExtractionConfig
+from bioscancast.stages.extraction.fetcher import FetchResult
+
+logger = logging.getLogger(__name__)
+
+# OWID CSVs can be large — the COVID file is ~70 MB, well past
+# ExtractionConfig.fetch_max_bytes (25 MB). These are trusted, static publisher
+# files, so the CSV fetch uses its own generous ceiling instead of the
+# streaming byte cap the generic fetcher applies. Guards runaway memory only.
+_OWID_CSV_MAX_BYTES = 250_000_000  # 250 MB
+
+CsvFetcher = Callable[[str, ExtractionConfig], Optional[str]]
+
+
+@dataclass(frozen=True)
+class OWIDDataset:
+    """Maps an OWID dashboard family to its structured CSV time series."""
+
+    name: str
+    csv_url: str
+    label: str
+    """Human label for the summary, e.g. ``"mpox"`` / ``"COVID-19"``."""
+    entity: str = "World"
+    """Default headline entity when the question names no specific location."""
+    location_col: str = "location"
+    date_col: str = "date"
+    value_col: str = "total_cases"
+    """Cumulative column that drives the series/snapshot/targeting ranking."""
+    cumulative_metrics: tuple[tuple[str, str], ...] = (
+        ("total_cases", "cumulative confirmed cases"),
+        ("total_deaths", "cumulative deaths"),
+    )
+    """(csv_column, human_phrase) pairs surfaced in the prose summary."""
+    trend_columns: tuple[str, ...] = ("date", "new_cases", "total_cases")
+    trend_rows: int = 16
+
+
+def _fetch_csv_text(url: str, cfg: ExtractionConfig) -> Optional[str]:
+    """Fetch a plain CSV over HTTP. Returns text, or None on failure.
+
+    Uses curl_cffi (the same client the rest of extraction uses) so we inherit
+    browser-TLS impersonation; these are static files so it is mostly belt-and-
+    braces. Unlike the generic fetcher this does not apply the 25 MB streaming
+    cap — the COVID CSV legitimately exceeds it.
+    """
+    try:
+        from curl_cffi import requests as curl_requests
+
+        resp = curl_requests.get(
+            url,
+            timeout=max(cfg.fetch_timeout_seconds, 60.0),
+            impersonate=cfg.impersonate,
+            allow_redirects=True,
+        )
+    except Exception as exc:  # noqa: BLE001 - network best-effort
+        logger.info("OWID CSV fetch failed for %s: %s", url, exc)
+        return None
+
+    if resp.status_code != 200 or not resp.content:
+        logger.info("OWID CSV fetch returned status=%s for %s", resp.status_code, url)
+        return None
+    if len(resp.content) > _OWID_CSV_MAX_BYTES:
+        logger.info(
+            "OWID CSV too large (%d bytes > %d) for %s",
+            len(resp.content), _OWID_CSV_MAX_BYTES, url,
+        )
+        return None
+    return resp.content.decode("utf-8", errors="replace")
+
+
+def _pick_col(fieldnames: list[str], options: tuple[str, ...]) -> str | None:
+    lowered = {name.lower(): name for name in fieldnames}
+    for opt in options:
+        found = lowered.get(opt.lower())
+        if found:
+            return found
+    return None
+
+
+def _parse_float(value: str | None) -> float | None:
+    if value is None:
+        return None
+    raw = value.strip().replace(",", "")
+    if not raw:
+        return None
+    try:
+        return float(raw)
+    except ValueError:
+        return None
+
+
+def _fmt_number(raw: str | None) -> str | None:
+    """Format an OWID numeric cell as a thousands-separated value.
+
+    OWID writes cumulative counts as floats (e.g. ``129602.0``). Returns None
+    for blank/non-numeric cells so absent metrics are omitted from the summary.
+    """
+    value = _parse_float(raw)
+    if value is None:
+        return None
+    if value == int(value):
+        return f"{int(value):,}"
+    return f"{value:,.2f}"
+
+
+def _parse_date(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    text = value.strip()
+    if not text:
+        return None
+    for fmt in ("%Y-%m-%d", "%Y/%m/%d"):
+        try:
+            return datetime.strptime(text, fmt).replace(tzinfo=timezone.utc)
+        except ValueError:
+            continue
+    return None
+
+
+def _as_utc(dt: datetime) -> datetime:
+    """Make a datetime tz-aware (UTC) so cutoff comparisons never raise."""
+    return dt if dt.tzinfo is not None else dt.replace(tzinfo=timezone.utc)
+
+
+def _infer_locations_from_question(
+    *,
+    question_text: str,
+    known_locations: set[str],
+) -> list[str]:
+    q = question_text.lower()
+    matches = [loc for loc in known_locations if loc.lower() in q]
+    matches.sort(key=len, reverse=True)
+    return matches[:3]
+
+
+def _resolve_target_locations(
+    *,
+    region: str | None,
+    question_text: str | None,
+    known_locations: set[str],
+) -> list[str]:
+    if region:
+        direct = [loc for loc in known_locations if loc.lower() == region.lower()]
+        if direct:
+            return direct
+
+    if question_text:
+        inferred = _infer_locations_from_question(
+            question_text=question_text,
+            known_locations=known_locations,
+        )
+        if inferred:
+            return inferred
+
+    for fallback in ("World", "Global"):
+        if fallback in known_locations:
+            return [fallback]
+    return []
+
+
+def _series_delta(series: list[tuple[datetime, float]], n_back: int) -> float | None:
+    if len(series) <= n_back:
+        return None
+    return series[-1][1] - series[-(n_back + 1)][1]
+
+
+def _cumulative_line(dataset: OWIDDataset, entity: str, dt: datetime, row: dict[str, str]) -> str:
+    """One prose sentence stating an entity's cumulative figures as of a date."""
+    parts = [f"As of {dt.date().isoformat()}, {html.escape(entity)}:"]
+    for column, phrase in dataset.cumulative_metrics:
+        value = _fmt_number(row.get(column))
+        if value is not None:
+            parts.append(f" {phrase} ({html.escape(entity)}): {value};")
+    return " ".join(parts).rstrip(";")
+
+
+def _trend_table_html(dataset: OWIDDataset, entity: str, ordered_rows: list[tuple[datetime, dict[str, str]]]) -> list[str]:
+    cols = [c for c in dataset.trend_columns if ordered_rows and c in ordered_rows[-1][1]]
+    if not cols:
+        return []
+    series = [(dt, row) for dt, row in ordered_rows if _parse_float(row.get(dataset.value_col)) is not None]
+    value_series = [(dt, _parse_float(row.get(dataset.value_col))) for dt, row in series]
+    d4 = _series_delta([(dt, v) for dt, v in value_series if v is not None], 4)
+    d12 = _series_delta([(dt, v) for dt, v in value_series if v is not None], 12)
+
+    lines = [f"<h3>{html.escape(entity)} — recent trend</h3>"]
+    if value_series and value_series[-1][1] is not None:
+        latest_dt, latest_val = value_series[-1]
+        lines.append(
+            f"<p>Latest {html.escape(dataset.value_col)} "
+            f"({latest_dt.date().isoformat()}): {latest_val:,.0f}; "
+            f"delta_4_rows: {d4 if d4 is not None else 'n/a'}; "
+            f"delta_12_rows: {d12 if d12 is not None else 'n/a'}</p>"
+        )
+    header = "".join(f"<th>{html.escape(c)}</th>" for c in cols)
+    lines.append(f"<table><thead><tr>{header}</tr></thead><tbody>")
+    for _dt, row in ordered_rows[-dataset.trend_rows:]:
+        cells = "".join(f"<td>{html.escape((row.get(c) or '').strip())}</td>" for c in cols)
+        lines.append(f"<tr>{cells}</tr>")
+    lines.append("</tbody></table>")
+    return lines
+
+
+def fetch_owid(
+    url: str,
+    dataset: OWIDDataset,
+    *,
+    config: ExtractionConfig | None = None,
+    as_of_date: datetime | None = None,
+    region: str | None = None,
+    question_text: str | None = None,
+    csv_fetcher: CsvFetcher | None = None,
+) -> FetchResult | None:
+    """Fetch an OWID dataset CSV and render it to a compact HTML summary.
+
+    Returns None on any failure (network, empty/changed schema, no rows before
+    the cutoff) so the dispatcher falls back to the generic fetch path rather
+    than dropping the document.
+    """
+    cfg = config or ExtractionConfig()
+    fetch_csv = csv_fetcher or _fetch_csv_text
+    fetched_at = datetime.now(timezone.utc)
+
+    text = fetch_csv(dataset.csv_url, cfg)
+    if not text:
+        return None
+
+    reader = csv.DictReader(io.StringIO(text))
+    fieldnames = list(reader.fieldnames or [])
+    rows = list(reader)
+    if not fieldnames or not rows:
+        return None
+
+    location_col = _pick_col(fieldnames, (dataset.location_col, "entity", "country", "location"))
+    date_col = _pick_col(fieldnames, (dataset.date_col, "day", "date", "year"))
+    value_col = _pick_col(fieldnames, (dataset.value_col,))
+    if not location_col or not date_col or not value_col:
+        return None
+
+    cutoff = _as_utc(as_of_date) if as_of_date else fetched_at
+
+    # Full per-location history (rows on-or-before the cutoff), date-ordered.
+    rows_by_location: dict[str, list[tuple[datetime, dict[str, str]]]] = {}
+    for row in rows:
+        location = (row.get(location_col) or "").strip()
+        if not location:
+            continue
+        dt = _parse_date(row.get(date_col))
+        if dt is None or dt > cutoff:
+            continue
+        if _parse_float(row.get(value_col)) is None:
+            continue
+        rows_by_location.setdefault(location, []).append((dt, row))
+
+    if not rows_by_location:
+        return None
+
+    for loc in rows_by_location:
+        rows_by_location[loc].sort(key=lambda item: item[0])
+
+    def latest_value(loc: str) -> float:
+        dt, row = rows_by_location[loc][-1]
+        return _parse_float(row.get(value_col)) or 0.0
+
+    # Headline entity: the dataset default (World) when present, else the
+    # largest-cumulative location so the summary is never empty.
+    if dataset.entity in rows_by_location:
+        headline = dataset.entity
+    else:
+        headline = max(rows_by_location, key=latest_value)
+
+    target_locations = _resolve_target_locations(
+        region=region,
+        question_text=question_text,
+        known_locations=set(rows_by_location.keys()),
+    )
+    # Always lead with the headline entity; then any question/region targets.
+    ordered_entities: list[str] = [headline]
+    for loc in target_locations:
+        if loc not in ordered_entities:
+            ordered_entities.append(loc)
+
+    top_locations = sorted(
+        (
+            (loc, rows_by_location[loc][-1][0], latest_value(loc))
+            for loc in rows_by_location
+            if loc not in {"World", "Global"}
+        ),
+        key=lambda item: item[2],
+        reverse=True,
+    )[:30]
+
+    summary_lines = [
+        "<html><head><meta charset='utf-8'>"
+        f"<title>Our World in Data — {html.escape(dataset.label)} summary</title></head><body>",
+        f"<h1>Our World in Data — {html.escape(dataset.label)}</h1>",
+        f"<p>CSV source: {html.escape(dataset.csv_url)}</p>",
+        f"<p>Cutoff: {cutoff.date().isoformat()}; "
+        f"locations with usable rows: {len(rows_by_location)}; "
+        f"region hint: {html.escape(region or '(none)')}</p>",
+    ]
+
+    # Prose headline: the extractable, unambiguous cumulative figure(s).
+    for entity in ordered_entities:
+        dt, row = rows_by_location[entity][-1]
+        summary_lines.append(f"<h2>{html.escape(entity)}</h2>")
+        summary_lines.append(
+            f"<p>Our World in Data — {html.escape(dataset.label)} ({html.escape(entity)}). "
+            f"{_cumulative_line(dataset, entity, dt, row)}. "
+            f"Source: {html.escape(dataset.csv_url)}.</p>"
+        )
+        summary_lines.extend(_trend_table_html(dataset, entity, rows_by_location[entity]))
+
+    if top_locations:
+        summary_lines.append("<h2>Top locations by latest cumulative value</h2>")
+        summary_lines.append(
+            "<table><thead><tr><th>Location</th><th>Date</th>"
+            f"<th>{html.escape(dataset.value_col)}</th></tr></thead><tbody>"
+        )
+        for loc, dt, value in top_locations:
+            summary_lines.append(
+                "<tr>"
+                f"<td>{html.escape(loc)}</td>"
+                f"<td>{dt.date().isoformat()}</td>"
+                f"<td>{value:,.0f}</td>"
+                "</tr>"
+            )
+        summary_lines.append("</tbody></table>")
+
+    summary_lines.append(
+        "<p>Note: this custom scraper summarizes OWID CSV rows into compact HTML "
+        "so the existing HTML extraction pipeline can process them "
+        "deterministically. Figures are cumulative totals as of the cutoff.</p>"
+    )
+    summary_lines.append("</body></html>")
+
+    rendered = "\n".join(summary_lines).encode("utf-8")
+    return FetchResult(
+        url=dataset.csv_url,
+        final_url=dataset.csv_url,
+        status_code=200,
+        content_type="text/html",
+        content_bytes=rendered,
+        fetched_at=fetched_at,
+        error=None,
+    )

--- a/bioscancast/stages/extraction/custom_scrapers/ourworldindata_covid.py
+++ b/bioscancast/stages/extraction/custom_scrapers/ourworldindata_covid.py
@@ -1,0 +1,52 @@
+"""Custom scraper for the OWID COVID-19 dashboard (``source_id: ourworldindata_covid``).
+
+Restores COVID parity with the earlier OWID work (issue #38, finding 3): the
+``ourworldindata_covid`` source had no scraper module, so extraction fell back
+to the generic fetch of a client-side-rendered page and captured zero records
+(the exact #34 failure). Fetches OWID's published COVID CSV time series and
+surfaces cumulative ``total_cases`` / ``total_deaths`` via the shared OWID core.
+
+Note: the OWID COVID CSV is large (~70 MB). The shared core fetches it with a
+raised byte ceiling rather than the generic 25 MB streaming cap.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from bioscancast.stages.extraction.config import ExtractionConfig
+from bioscancast.stages.extraction.custom_scrapers._owid_common import (
+    CsvFetcher,
+    OWIDDataset,
+    fetch_owid,
+)
+from bioscancast.stages.extraction.fetcher import FetchResult
+
+COVID_DATASET = OWIDDataset(
+    name="owid-covid",
+    csv_url=(
+        "https://raw.githubusercontent.com/owid/covid-19-data/master/"
+        "public/data/owid-covid-data.csv"
+    ),
+    label="COVID-19",
+)
+
+
+def fetch(
+    url: str,
+    *,
+    config: ExtractionConfig | None = None,
+    as_of_date: datetime | None = None,
+    region: str | None = None,
+    question_text: str | None = None,
+    csv_fetcher: CsvFetcher | None = None,
+) -> FetchResult | None:
+    return fetch_owid(
+        url,
+        COVID_DATASET,
+        config=config,
+        as_of_date=as_of_date,
+        region=region,
+        question_text=question_text,
+        csv_fetcher=csv_fetcher,
+    )

--- a/bioscancast/stages/extraction/custom_scrapers/ourworldindata_mpox.py
+++ b/bioscancast/stages/extraction/custom_scrapers/ourworldindata_mpox.py
@@ -1,191 +1,32 @@
+"""Custom scraper for the OWID mpox dashboard (``source_id: ourworldindata_mpox``).
+
+Fetches OWID's published mpox CSV time series (canonical GitHub raw — the
+grapher/explorer ``.csv`` slug endpoints from #34 are unstable and the explorer
+endpoint only exposes 7-day-smoothed *new* cases, not the cumulative totals the
+benchmark questions resolve on; see #38) and surfaces cumulative ``total_cases``
+/ ``total_deaths`` via the shared OWID core.
+"""
+
 from __future__ import annotations
 
-import csv
-import html
-import io
-from datetime import datetime, timezone
-from typing import Optional
-
-from curl_cffi import requests as curl_requests
+from datetime import datetime
 
 from bioscancast.stages.extraction.config import ExtractionConfig
+from bioscancast.stages.extraction.custom_scrapers._owid_common import (
+    CsvFetcher,
+    OWIDDataset,
+    fetch_owid,
+)
 from bioscancast.stages.extraction.fetcher import FetchResult
 
-_OWID_MPOX_CSV_URL = (
-    "https://ourworldindata.org/explorers/monkeypox.csv?"
-    "v=1&csvType=full&useColumnShortNames=true&"
-    "Metric=Confirmed+cases&Frequency=7-day+average&Relative+to+population=false"
+MPOX_DATASET = OWIDDataset(
+    name="owid-mpox",
+    csv_url=(
+        "https://raw.githubusercontent.com/owid/monkeypox/main/"
+        "owid-monkeypox-data.csv"
+    ),
+    label="mpox",
 )
-
-
-def _normalize_content_type(header_value: Optional[str]) -> Optional[str]:
-    if not header_value:
-        return None
-    return header_value.split(";", 1)[0].strip().lower()
-
-
-def _fetch_bytes(
-    url: str,
-    cfg: ExtractionConfig,
-) -> tuple[Optional[bytes], str, Optional[int], Optional[str], Optional[str]]:
-    try:
-        response = curl_requests.get(
-            url,
-            stream=True,
-            timeout=cfg.fetch_timeout_seconds,
-            impersonate=cfg.impersonate,
-            allow_redirects=True,
-        )
-        try:
-            content_length = response.headers.get("content-length")
-            if content_length and int(content_length) > cfg.fetch_max_bytes:
-                return (
-                    None,
-                    str(response.url),
-                    response.status_code,
-                    _normalize_content_type(response.headers.get("content-type")),
-                    f"Content-Length {content_length} exceeds max {cfg.fetch_max_bytes} bytes",
-                )
-
-            chunks: list[bytes] = []
-            total = 0
-            for chunk in response.iter_content():
-                total += len(chunk)
-                if total > cfg.fetch_max_bytes:
-                    return (
-                        None,
-                        str(response.url),
-                        response.status_code,
-                        _normalize_content_type(response.headers.get("content-type")),
-                        f"Response exceeded max {cfg.fetch_max_bytes} bytes during streaming",
-                    )
-                chunks.append(chunk)
-
-            return (
-                b"".join(chunks),
-                str(response.url),
-                response.status_code,
-                _normalize_content_type(response.headers.get("content-type")),
-                None,
-            )
-        finally:
-            response.close()
-    except Exception as exc:  # noqa: BLE001
-        return None, url, None, None, str(exc)
-
-
-def _pick_col(fieldnames: list[str], options: tuple[str, ...]) -> str | None:
-    lowered = {name.lower(): name for name in fieldnames}
-    for opt in options:
-        found = lowered.get(opt.lower())
-        if found:
-            return found
-    return None
-
-
-def _parse_float(value: str | None) -> float | None:
-    if value is None:
-        return None
-    raw = value.strip().replace(",", "")
-    if not raw:
-        return None
-    try:
-        return float(raw)
-    except ValueError:
-        return None
-
-
-def _parse_date(value: str | None) -> datetime | None:
-    if not value:
-        return None
-    text = value.strip()
-    if not text:
-        return None
-    # OWID dates are usually YYYY-MM-DD.
-    for fmt in ("%Y-%m-%d", "%Y/%m/%d"):
-        try:
-            return datetime.strptime(text, fmt).replace(tzinfo=timezone.utc)
-        except ValueError:
-            continue
-    return None
-
-
-def _resolve_metric_col(fieldnames: list[str], rows: list[dict[str, str]]) -> str | None:
-    preferred = (
-        "Confirmed cases",
-        "Confirmed cases (7-day average)",
-        "cases",
-        "value",
-    )
-    direct = _pick_col(fieldnames, preferred)
-    if direct:
-        return direct
-
-    excluded = {
-        "entity",
-        "country",
-        "location",
-        "code",
-        "iso code",
-        "iso_code",
-        "day",
-        "date",
-        "year",
-    }
-    candidates = [f for f in fieldnames if f.lower() not in excluded]
-    best_col: str | None = None
-    best_score = -1
-    for col in candidates:
-        numeric_count = 0
-        for row in rows:
-            if _parse_float(row.get(col)) is not None:
-                numeric_count += 1
-        if numeric_count > best_score:
-            best_score = numeric_count
-            best_col = col
-    return best_col
-
-
-def _infer_locations_from_question(
-    *,
-    question_text: str,
-    known_locations: set[str],
-) -> list[str]:
-    q = question_text.lower()
-    matches = [loc for loc in known_locations if loc.lower() in q]
-    matches.sort(key=len, reverse=True)
-    return matches[:3]
-
-
-def _resolve_target_locations(
-    *,
-    region: str | None,
-    question_text: str | None,
-    known_locations: set[str],
-) -> list[str]:
-    if region:
-        direct = [loc for loc in known_locations if loc.lower() == region.lower()]
-        if direct:
-            return direct
-
-    if question_text:
-        inferred = _infer_locations_from_question(
-            question_text=question_text,
-            known_locations=known_locations,
-        )
-        if inferred:
-            return inferred
-
-    for fallback in ("World", "Global"):
-        if fallback in known_locations:
-            return [fallback]
-    return []
-
-
-def _series_delta(series: list[tuple[datetime, float]], n_back: int) -> float | None:
-    if len(series) <= n_back:
-        return None
-    return series[-1][1] - series[-(n_back + 1)][1]
 
 
 def fetch(
@@ -195,154 +36,14 @@ def fetch(
     as_of_date: datetime | None = None,
     region: str | None = None,
     question_text: str | None = None,
+    csv_fetcher: CsvFetcher | None = None,
 ) -> FetchResult | None:
-    cfg = config or ExtractionConfig()
-    fetched_at = datetime.now(timezone.utc)
-    csv_url = _OWID_MPOX_CSV_URL
-
-    content_bytes, final_url, status_code, _content_type, err = _fetch_bytes(csv_url, cfg)
-    if err is not None or content_bytes is None:
-        return None
-
-    text = content_bytes.decode("utf-8-sig", errors="replace")
-    reader = csv.DictReader(io.StringIO(text))
-    fieldnames = list(reader.fieldnames or [])
-    rows = list(reader)
-    if not fieldnames or not rows:
-        return None
-
-    location_col = _pick_col(fieldnames, ("Entity", "Country", "Location"))
-    date_col = _pick_col(fieldnames, ("Day", "Date", "Year"))
-    metric_col = _resolve_metric_col(fieldnames, rows)
-    if not location_col or not date_col or not metric_col:
-        return None
-
-    cutoff = as_of_date or fetched_at
-    latest_by_location: dict[str, tuple[datetime, float]] = {}
-    for row in rows:
-        location = (row.get(location_col) or "").strip()
-        if not location:
-            continue
-        dt = _parse_date(row.get(date_col))
-        if dt is None or dt > cutoff:
-            continue
-        metric_val = _parse_float(row.get(metric_col))
-        if metric_val is None:
-            continue
-        current = latest_by_location.get(location)
-        if current is None or dt > current[0]:
-            latest_by_location[location] = (dt, metric_val)
-
-    if not latest_by_location:
-        return None
-
-    # Build full per-location time series for trend extraction.
-    series_by_location: dict[str, list[tuple[datetime, float]]] = {}
-    for row in rows:
-        location = (row.get(location_col) or "").strip()
-        if not location:
-            continue
-        dt = _parse_date(row.get(date_col))
-        if dt is None or dt > cutoff:
-            continue
-        metric_val = _parse_float(row.get(metric_col))
-        if metric_val is None:
-            continue
-        series_by_location.setdefault(location, []).append((dt, metric_val))
-
-    for loc in list(series_by_location.keys()):
-        series_by_location[loc].sort(key=lambda item: item[0])
-
-    world_snapshot = None
-    for key in ("World", "Global"):
-        if key in latest_by_location:
-            world_snapshot = (key, latest_by_location[key])
-            break
-
-    top_locations = sorted(
-        (
-            (loc, dt_val[0], dt_val[1])
-            for loc, dt_val in latest_by_location.items()
-            if loc not in {"World", "Global"}
-        ),
-        key=lambda item: item[2],
-        reverse=True,
-    )[:30]
-
-    target_locations = _resolve_target_locations(
+    return fetch_owid(
+        url,
+        MPOX_DATASET,
+        config=config,
+        as_of_date=as_of_date,
         region=region,
         question_text=question_text,
-        known_locations=set(series_by_location.keys()),
-    )
-
-    summary_lines = [
-        "<html><head><meta charset='utf-8'><title>OWID Mpox CSV Summary</title></head><body>",
-        "<h1>Our World in Data - Mpox CSV Summary</h1>",
-        f"<p>CSV source: {html.escape(final_url)}</p>",
-        f"<p>Metric column: {html.escape(metric_col)}</p>",
-        f"<p>Locations with usable rows: {len(latest_by_location)}</p>",
-        f"<p>Region hint: {html.escape(region or '(none)')}</p>",
-    ]
-
-    if world_snapshot is not None:
-        world_loc, (world_dt, world_value) = world_snapshot
-        summary_lines.append(
-            "<h2>Latest global snapshot</h2>"
-            f"<p>{html.escape(world_loc)} on {world_dt.date().isoformat()}: {world_value:,.2f}</p>"
-        )
-
-    summary_lines.append("<h2>Top locations by latest value</h2>")
-    summary_lines.append("<table><thead><tr><th>Location</th><th>Date</th><th>Value</th></tr></thead><tbody>")
-    for loc, dt, value in top_locations:
-        summary_lines.append(
-            "<tr>"
-            f"<td>{html.escape(loc)}</td>"
-            f"<td>{dt.date().isoformat()}</td>"
-            f"<td>{value:,.2f}</td>"
-            "</tr>"
-        )
-    summary_lines.append("</tbody></table>")
-
-    if target_locations:
-        summary_lines.append("<h2>Target Region Time Series (recent)</h2>")
-        for loc in target_locations:
-            series = series_by_location.get(loc, [])
-            if not series:
-                continue
-            latest_dt, latest_value = series[-1]
-            d4 = _series_delta(series, 4)
-            d12 = _series_delta(series, 12)
-            summary_lines.append(f"<h3>{html.escape(loc)}</h3>")
-            summary_lines.append(
-                f"<p>Latest ({latest_dt.date().isoformat()}): {latest_value:,.2f}; "
-                f"delta_4_points: {d4 if d4 is not None else 'n/a'}; "
-                f"delta_12_points: {d12 if d12 is not None else 'n/a'}</p>"
-            )
-            summary_lines.append(
-                "<table><thead><tr><th>Date</th><th>Value</th></tr></thead><tbody>"
-            )
-            for dt, value in series[-16:]:
-                summary_lines.append(
-                    "<tr>"
-                    f"<td>{dt.date().isoformat()}</td>"
-                    f"<td>{value:,.2f}</td>"
-                    "</tr>"
-                )
-            summary_lines.append("</tbody></table>")
-
-    summary_lines.append(
-        "<p>Note: This custom scraper summarizes CSV rows into compact HTML so the existing "
-        "HTML extraction pipeline can process it deterministically.</p>"
-    )
-    summary_lines.append("</body></html>")
-
-    rendered = "\n".join(summary_lines).encode("utf-8")
-    return FetchResult(
-        url=csv_url,
-        final_url=final_url,
-        status_code=status_code,
-        content_type="text/html",
-        content_bytes=rendered,
-        fetched_at=fetched_at,
-        error=None,
+        csv_fetcher=csv_fetcher,
     )

--- a/bioscancast/tests/test_owid_custom_scrapers.py
+++ b/bioscancast/tests/test_owid_custom_scrapers.py
@@ -1,0 +1,198 @@
+"""Tests for the OWID custom scrapers (issues #34 / #38).
+
+No network: the scrapers accept an injected ``csv_fetcher`` returning fixture
+text. Adapted from the feature-branch ``test_extraction_dashboards.py`` to the
+``source_id``-dispatched ``custom_scrapers.<id>.fetch() -> FetchResult`` contract.
+Assertions target the rendered HTML summary (``content_bytes``) rather than a
+``ParsedContent``, and entity isolation is expressed as "the World cumulative
+figure is not contaminated" (the scraper also renders a top-locations table,
+so other entities' values legitimately appear elsewhere).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from bioscancast.stages.extraction.config import ExtractionConfig
+from bioscancast.stages.extraction.custom_scrapers import (
+    ourworldindata_covid,
+    ourworldindata_mpox,
+)
+
+# A tiny OWID-shaped mpox CSV: World + another entity, a few dates.
+_MPOX_CSV = (
+    "location,date,iso_code,total_cases,total_deaths,new_cases\n"
+    "World,2025-02-20,OWID_WRL,129500.0,250.0,30.0\n"
+    "World,2025-02-24,OWID_WRL,129602.0,254.0,20.0\n"
+    "World,2025-02-27,OWID_WRL,129603.0,254.0,1.0\n"
+    "World,2025-03-05,OWID_WRL,129999.0,260.0,80.0\n"
+    "Africa,2025-02-24,OWID_AFR,40000.0,200.0,10.0\n"
+    "Africa,2025-03-05,OWID_AFR,41000.0,205.0,20.0\n"
+)
+
+_COVID_CSV = (
+    "iso_code,continent,location,date,total_cases,total_deaths,new_cases\n"
+    "OWID_WRL,,World,2022-12-31,732000000.0,6800000.0,400000.0\n"
+    "OWID_WRL,,World,2023-01-01,732363539.0,6810000.0,363539.0\n"
+    "OWID_WRL,,World,2023-01-05,733000000.0,6820000.0,200000.0\n"
+)
+
+
+def _mpox_fetch(csv_text: str = _MPOX_CSV):
+    return lambda url, config: csv_text
+
+
+def _asof(s: str) -> datetime:
+    return datetime.strptime(s, "%Y-%m-%d").replace(tzinfo=timezone.utc)
+
+
+def _html(result) -> str:
+    assert result is not None
+    return result.content_bytes.decode("utf-8")
+
+
+class TestMpoxCumulativeMetric:
+    def test_cutoff_selects_cumulative_value_as_of_date(self):
+        result = ourworldindata_mpox.fetch(
+            "https://ourworldindata.org/mpox",
+            as_of_date=_asof("2025-02-24"),
+            csv_fetcher=_mpox_fetch(),
+        )
+        body = _html(result)
+        # The cumulative figure as of the cutoff, not the later 129,999.
+        assert "cumulative confirmed cases (World): 129,602" in body
+        assert "cumulative deaths (World): 254" in body
+        assert "129,999" not in body
+        assert result.content_type == "text/html"
+
+    def test_later_cutoff_advances_value(self):
+        body = _html(
+            ourworldindata_mpox.fetch(
+                "https://ourworldindata.org/mpox",
+                as_of_date=_asof("2025-02-27"),
+                csv_fetcher=_mpox_fetch(),
+            )
+        )
+        assert "cumulative confirmed cases (World): 129,603" in body
+
+    def test_live_mode_uses_latest_row(self):
+        body = _html(
+            ourworldindata_mpox.fetch(
+                "https://ourworldindata.org/mpox",
+                as_of_date=None,
+                csv_fetcher=_mpox_fetch(),
+            )
+        )
+        assert "cumulative confirmed cases (World): 129,999" in body
+
+    def test_world_figure_not_contaminated_by_other_entity(self):
+        # Africa's 40,000 may appear in the top-locations table, but must never
+        # be surfaced as the World cumulative figure.
+        body = _html(
+            ourworldindata_mpox.fetch(
+                "https://ourworldindata.org/mpox",
+                as_of_date=_asof("2025-02-24"),
+                csv_fetcher=_mpox_fetch(),
+            )
+        )
+        assert "cumulative confirmed cases (World): 40,000" not in body
+        assert "cumulative confirmed cases (World): 129,602" in body
+
+    def test_emits_prose_and_trend_table(self):
+        body = _html(
+            ourworldindata_mpox.fetch(
+                "https://ourworldindata.org/mpox",
+                as_of_date=_asof("2025-03-05"),
+                csv_fetcher=_mpox_fetch(),
+            )
+        )
+        assert "<table" in body
+        # Trend columns present, and the last World trend row is the cutoff date.
+        assert "<th>total_cases</th>" in body
+        assert "2025-03-05" in body
+
+    def test_returns_none_when_no_rows_before_cutoff(self):
+        assert (
+            ourworldindata_mpox.fetch(
+                "https://ourworldindata.org/mpox",
+                as_of_date=_asof("2020-01-01"),
+                csv_fetcher=_mpox_fetch(),
+            )
+            is None
+        )
+
+    def test_returns_none_on_fetch_failure(self):
+        assert (
+            ourworldindata_mpox.fetch(
+                "https://ourworldindata.org/mpox",
+                as_of_date=None,
+                csv_fetcher=lambda url, config: None,
+            )
+            is None
+        )
+
+
+class TestLocationTargeting:
+    def test_region_surfaces_target_entity(self):
+        body = _html(
+            ourworldindata_mpox.fetch(
+                "https://ourworldindata.org/mpox",
+                as_of_date=_asof("2025-03-05"),
+                region="Africa",
+                csv_fetcher=_mpox_fetch(),
+            )
+        )
+        assert "<h2>Africa</h2>" in body
+        assert "cumulative confirmed cases (Africa): 41,000" in body
+
+    def test_question_text_infers_target_entity(self):
+        body = _html(
+            ourworldindata_mpox.fetch(
+                "https://ourworldindata.org/mpox",
+                as_of_date=_asof("2025-02-24"),
+                question_text="Will mpox cases increase in Africa in 2025?",
+                csv_fetcher=_mpox_fetch(),
+            )
+        )
+        assert "<h2>Africa</h2>" in body
+        # World is still led with as the headline entity.
+        assert "cumulative confirmed cases (World): 129,602" in body
+
+
+class TestCovidDataset:
+    def test_covid_cumulative_regression(self):
+        # Feature-branch regression criterion: 732,363,539 @2023-01-01.
+        body = _html(
+            ourworldindata_covid.fetch(
+                "https://ourworldindata.org/coronavirus",
+                as_of_date=_asof("2023-01-01"),
+                csv_fetcher=lambda url, config: _COVID_CSV,
+            )
+        )
+        assert "cumulative confirmed cases (World): 732,363,539" in body
+        assert "733,000,000" not in body  # later row excluded by cutoff
+
+
+class TestDispatchRouting:
+    def test_dispatcher_routes_source_id_through_custom_scraper(self, monkeypatch):
+        """fetcher.fetch(source_id=...) must use the custom scraper and tag the
+        result fetch_strategy=custom:<source_id>, with no network."""
+        from bioscancast.stages.extraction import fetcher as fetcher_mod
+        from bioscancast.stages.extraction.custom_scrapers import _owid_common
+
+        monkeypatch.setattr(
+            _owid_common, "_fetch_csv_text", lambda url, cfg: _MPOX_CSV
+        )
+
+        result = fetcher_mod.fetch(
+            "https://ourworldindata.org/mpox",
+            config=ExtractionConfig(),
+            as_of_date=_asof("2025-02-24"),
+            source_id="ourworldindata_mpox",
+        )
+        assert result is not None
+        assert result.fetch_strategy == "custom:ourworldindata_mpox"
+        assert result.content_type == "text/html"
+        assert "cumulative confirmed cases (World): 129,602" in _html(result)

--- a/data/investigations/issue-34-owid-dashboard-fetch.md
+++ b/data/investigations/issue-34-owid-dashboard-fetch.md
@@ -1,0 +1,107 @@
+# Issue #34 — OWID dashboard data fetch (mpox + COVID)
+
+Date: 2026-06-22 · Branch: `feat/pipeline-tuning` · Commit: `0fac291`
+
+> **Update (issue #38, port onto the refactor).** The logic below was
+> originally written as a `DashboardExtractor` under
+> `bioscancast/extraction/dashboards/`. On `main` it now lives in the
+> `source_id`-dispatched custom-scraper framework:
+> `bioscancast/stages/extraction/custom_scrapers/_owid_common.py` (shared core)
+> with thin `ourworldindata_mpox.py` / `ourworldindata_covid.py` modules. The
+> data source (GitHub-raw cumulative CSV), the cumulative-metric fix, the
+> as-of-date cutoff, and the revision caveat below are unchanged; the new
+> version additionally layers PR #37's question/region location targeting on
+> top. Tests: `bioscancast/tests/test_owid_custom_scrapers.py`.
+
+## Problem
+
+q7/q8 (mpox) extracted **zero insight records** → forecasts fell back to model
+priors (the two worst questions in the postfix benchmark, Brier 0.818/0.733).
+Root cause was extraction, not search/filter: OWID renders its charts
+client-side (static scrape = prose + citations, no numbers) and the WHO
+emergencies URL is an index landing page (~260 chars of links). Both reported
+`status="success"` (the silent-truncation class the Track E guard now flags).
+
+## Solution — extensible dashboard-fetcher framework
+
+`bioscancast/extraction/dashboards/`:
+- `base.DashboardExtractor` — strategy ABC (`matches(url)`, `extract(url, *,
+  as_of_date, config) -> ParsedContent | None`).
+- `__init__.DASHBOARD_EXTRACTORS` + `find_dashboard_extractor(url)` — registry;
+  add a new tricky dashboard by appending an extractor.
+- `owid.OWIDDashboardExtractor` — fetches OWID's published CSV time series
+  (canonical GitHub raw — the grapher `.csv` slugs in #34 now 404), selects the
+  entity (default `World`), applies the as-of cutoff as a row filter, emits a
+  prose summary + recent-trend table. Datasets: mpox + COVID-19, same schema.
+
+Wired into `ExtractionPipeline.extract_one` *before* the generic fetch path; a
+match that yields nothing falls back to generic fetch (never drops the doc).
+Shared `_finalize_document` builds the Document for both paths. New
+`fetch_strategy="dashboard:owid"`, `document_type="dashboard_csv"`.
+
+Because the CSV carries full history, replay needs **no Wayback snapshot** for
+these sources — sidesteps the snapshot-selection fragility from Track E.
+Caveat: replay uses *today's CSV's* estimate of the cutoff-date value (OWID
+revises history), not the value as published then — far smaller error than the
+zero-record fallback, and exactly right for live mode.
+
+## Validation
+
+Live OWID data (the extractor, real fetch):
+- mpox World cumulative **129,602 @2025-02-24**, **129,603 @2025-02-27** (the
+  previously zero-record cutoffs)
+- COVID **732,363,539 @2023-01-01** (regression criterion — COVID path works)
+
+End-to-end on the **saved** q7@2025-02-24 filtered docs (extract + insight, no
+Tavily): OWID doc now `dashboard_csv`, prose+table chunks; insight yields
+**1 record** `confirmed_cases=129,602` (date 2025-02-24, conf 0.9, valid
+quote) vs **0 records** pre-fix. ✅ Acceptance criterion 1.
+
+Tests: `test_extraction_dashboards.py` (matching incl. Wayback wrapper, cutoff
+filtering, entity isolation, live-vs-replay, fetch-failure fallback, pipeline
+routing). Full suite: 284 passed / 3 skipped.
+
+## Full trajectory re-score (acceptance criterion 2) — MIXED, and instructive
+
+Regenerated q7 (4 cutoffs) + q8 (5 cutoffs) full pipelines with #34 enabled
+(`data/investigations/issue34/`, 2026-06-22). #34 fired in every run: each
+cutoff now has 1 `dashboard_csv` doc and real insight records
+(q7 `confirmed_cases=129,602 @02-24`, `129,603 @02-27`; was **0 records**).
+
+| question | pre-#34 Brier | post-#34 Brier | verdict |
+|---|---|---|---|
+| q8 (resolve 131,001+) | 0.733 | **0.000** | clean win |
+| q7 (resolve 126,001-128,500) | 0.818 | **~1.995** | regression — but a data-vintage artifact, not a pipeline defect |
+
+**q8 is a clean win:** resolution `131,001+` is robust across OWID vintages
+(contemporaneous and current both clear the floor), so feeding the model the
+real cumulative figure makes it confidently correct at all 5 cutoffs.
+
+**q7's "regression" is the OWID revision caveat made real.** q7's
+contemporaneous ground truth is **126,441** (→ bucket `126,001-128,500`), but
+OWID has since **retrospectively revised** the 2025-02-28 figure up to
+**~130,142** (→ `128,501-131,000`). #34 feeds the model OWID's *current* series
+(~129,602 climbing), so it confidently lands in the revised bucket and misses
+the contemporaneous truth. Pre-#34 it had no data and fell to a prior that
+happened to score better. This is exactly the caveat in `owid.py`'s docstring,
+and `bfg-manual-resolutions.md` pre-flagged it ("q7/q8 ground truth is
+tracker- and vintage-dependent").
+
+**Interpretation.** The plan's objective is *live* forecast quality, with the
+replay benchmark as the measurement instrument. For live forecasting #34 is
+unambiguously correct — the model now sees the real cumulative figure instead
+of guessing. q7's replay score is confounded by retrospective revision, a
+limitation of the *instrument* on revised-data sources, not of #34. Net: 1
+clean win (q8), 1 instrument-confounded case (q7); criterion 2 is met where the
+ground truth is vintage-stable.
+
+## Remaining
+- Large COVID CSV (~70 MB) is downloaded per run; consider a cached/streamed
+  fetch if COVID questions become hot (follow-up, not blocking).
+- #34's proposed grapher-`.csv` URL is dead; the issue text would want updating
+  to the GitHub-raw source (logging is the user's call).
+- **Replay fidelity on revised data (q7):** to make historical replay faithful
+  for OWID, the extractor could fetch the CSV *as of the cutoff* via OWID's git
+  history (commit-pinned raw URL) rather than today's `main`. Improves benchmark
+  fidelity only — live forecasting already wants the current series. Substantial;
+  not built.


### PR DESCRIPTION
## Summary

The OWID mpox custom scraper fetched the explorer endpoint
(`Metric=Confirmed cases&Frequency=7-day average`), which exposes only
`new_cases_smoothed` — a ~2-digit daily-incidence number. The benchmark mpox
questions (q7/q8) resolve on **cumulative** counts (~130,000), so the scraper
fed the model a confidently-wrong figure ([#38](https://github.com/algorithmicgovernance/BioScanCast/issues/38), finding 1). Separately, the
`ourworldindata_covid` source had **no scraper module**, so COVID fell back to a
client-side-rendered page and captured zero records — the exact [#34](https://github.com/algorithmicgovernance/BioScanCast/issues/34) failure.

This ports the OWID logic validated on `feat/pipeline-tuning` into the new
`source_id`-dispatched custom-scraper framework, and layers PR #37's location
targeting on top.

## Changes

- **`custom_scrapers/_owid_common.py`** — shared core: fetches OWID's canonical
  GitHub-raw CSV, applies the as-of-date cutoff as a row filter, and renders a
  compact HTML summary surfacing cumulative `total_cases` + `total_deaths`. Uses
  a raised byte ceiling because the COVID CSV (~70 MB) exceeds
  `ExtractionConfig.fetch_max_bytes` (25 MB).
- **`custom_scrapers/ourworldindata_mpox.py`** — thin dataset module, replacing
  the 7-day-metric version.
- **`custom_scrapers/ourworldindata_covid.py`** — new module restoring COVID
  parity.
- **Location targeting** — PR #37's question/region targeting is preserved and
  layered on the (previously World-only) summary.
- **`tests/test_owid_custom_scrapers.py`** — adapted from the feature-branch
  `test_extraction_dashboards.py` to the `fetch() -> FetchResult` contract:
  cutoff selection, entity isolation, live-vs-replay, targeting, COVID
  regression, dispatcher routing (11 tests).
- **`data/investigations/issue-34-owid-dashboard-fetch.md`** — carried over from
  the feature branch, annotated with the new module locations.

## Verification

- Full suite: **468 passed, 2 skipped**.
- Live check against real OWID data: mpox **World cumulative = 129,602
  @2025-02-24** (matches the documented feature-branch figure). Deaths now read
  311 vs June's 254 — OWID retrospectively revised deaths, exactly the vintage
  caveat in the investigation doc, not a regression.

## Deferred (not in this PR)

End-to-end **q7/q8 trajectory regeneration + Brier re-scoring** (#34 acceptance
criterion 2) is **not** included: the forecasting stage + trajectory driver live
on the pre-refactor `feat/pipeline-tuning` branch and aren't yet ported to
post-refactor `main`. That re-scoring was already performed there with the same
OWID logic (q8 Brier 0.733 -> 0.000; q7 confounded by OWID's retrospective
revision — see the investigation doc). Tracked as a follow-up.

Because of that, this PR **closes #38** and **addresses the extraction root
cause of #34** but does not close #34 — that stays open until the trajectory
tooling is ported and q7/q8 are re-scored on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)