### PR TITLE
Insight extraction: fix count-basis schema defects, add data_quality, harden against the "lurch"

### DIFF
--- a/bioscancast/schemas/insight_record.py
+++ b/bioscancast/schemas/insight_record.py
@@ -71,17 +71,35 @@ class InsightRecord:
     """Unit of the metric (e.g. 'cases', 'herds', 'deaths')."""
 
     count_basis: Optional[str] = None
-    """How the metric is defined: cumulative, incident, active,
-    prevalence, or unknown."""
+    """How the metric is counted: ``'cumulative'`` (running total to date),
+    ``'incident'`` (new in a stated period), ``'active'`` (currently active),
+    ``'prevalence'`` (point-prevalent), or ``'unknown'``. Distinguishes
+    epidemiologically different numbers that would otherwise flatten to the
+    same ``metric_name``/``metric_value`` (e.g. "282 cumulative" vs "282 new
+    this week" vs "282 active"). Extracted, never inferred beyond explicit
+    textual cues. Orthogonal to the (separate, planned) ``value_basis`` axis
+    that distinguishes observed from projected/modeled numbers."""
 
     time_window: Optional[str] = None
-    """Reporting period for incident metrics (e.g. day, week,
-    month, year, or unknown). None when not applicable or not stated."""
+    """Reporting period for an *incident* count: ``'day'``, ``'week'``,
+    ``'month'``, ``'year'``, or ``'unknown'``. ``'unknown'`` for
+    cumulative/active/prevalence counts, which have no window."""
 
     surveillance_method: Optional[str] = None
-    """Surveillance or ascertainment method explicitly stated in the
-    source (e.g. laboratory surveillance, syndromic surveillance,
-    enhanced surveillance)."""
+    """Surveillance/ascertainment method, captured only when explicitly
+    stated in the source (e.g. 'laboratory surveillance', 'syndromic
+    surveillance', 'enhanced surveillance', 'passive reporting'). ``None``
+    when not stated. Never inferred."""
+
+    data_quality: Optional[str] = None
+    """Explicit data-quality caveat stated in the source about how the
+    reported numbers relate to reality: under-reporting, limited
+    testing/ascertainment, reporting lag, suspected-vs-confirmed definition
+    issues, or a surveillance/case-definition change (e.g. 'testing capacity
+    limited; many mild cases not captured'). ``None`` when the source states
+    no such caveat. Never inferred from a number alone — the forecasting
+    stage decides what to do with it. Surfaced in the evidence digest even
+    on metric-bearing records (whose ``summary`` the digest otherwise omits)."""
 
     event_date: Optional[datetime] = None
     """Date the fact pertains to (not the date it was reported).

--- a/bioscancast/stages/insight/text_extraction/chunk_extractor.py
+++ b/bioscancast/stages/insight/text_extraction/chunk_extractor.py
@@ -447,6 +447,7 @@ def extract_facts_from_chunk(
             count_basis=fact.get("count_basis"),
             time_window=fact.get("time_window"),
             surveillance_method=fact.get("surveillance_method"),
+            data_quality=fact.get("data_quality"),
             event_date=event_date,
             event_date_precision=event_date_precision,
             summary=fact.get("summary"),

--- a/bioscancast/stages/insight/text_extraction/prompts.py
+++ b/bioscancast/stages/insight/text_extraction/prompts.py
@@ -5,6 +5,12 @@ Key design principles:
 - Require a verbatim quote (<=200 chars) for each fact.
 - Allow zero facts (common and valid for irrelevant chunks).
 - Include the forecast question for context but forbid answering it.
+- Only OBSERVED counts become case_count/death_count; projected, modeled,
+  and off-scope numbers are kept as context, not observed metrics, and
+  confidence tracks how well a fact's scope matches the question. This
+  guards the "lurch" failure where a projection or wrong-scope figure was
+  filed as an observed count at high confidence (rules 7-9); the
+  bioscancast/tests/test_insight_extraction_traps.py trap-set pins it.
 - Brief cognitive bias warnings from the grant proposal's Table 5.
 
 Note: full cognitive bias mitigations belong in the forecasting stage,
@@ -68,21 +74,57 @@ metric_name — capture those in `summary` or `location` instead. \
 "suspected cases", "probable cases", "possible cases" all map to \
 suspected_cases. "deaths" alone maps to deaths; "suspected deaths", \
 "probable deaths", "deaths under investigation" map to suspected_deaths.
-6b. For count_basis, choose one of:
-   - cumulative: total cases/deaths/etc. to date
-   - incident: new cases/deaths during a period
-   - active: currently active cases
-   - prevalence: point/prevalent cases
-   - unknown: if the text does not make this clear
-7. For time_window, choose one of:
-   - day
-   - week
-   - month
-   - year
-   - unknown
-   Use this only when the chunk explicitly gives a reporting period (e.g. "this week", "in January 2026"). Otherwise leave it null or "unknown".
-8. For surveillance_method, capture an explicitly stated surveillance or ascertainment method only (e.g. laboratory surveillance, syndromic surveillance, enhanced surveillance, passive reporting). Do not infer it.
-9. Be aware of cognitive biases that affect information processing:
+7. OBSERVED vs NON-OBSERVED. event_type ``case_count`` and ``death_count`` \
+are for OBSERVED, actually-reported counts ONLY. NEVER assign them to a \
+number that is projected, modeled, forecasted, simulated, estimated, \
+hypothetical, or a target/threshold — even when the number is stated \
+plainly (e.g. "could see as many as 10,000 cases by year-end", "one in 20 \
+simulations projected ..."). For such a number, set event_type ``other``, \
+leave metric_value null, and describe it in ``summary`` (note it is a \
+projection/model output and give its horizon and scenario if stated).
+8. SCOPE MATCH. A number pertains to the question only if its metric, its \
+geography, AND its time window all match the question's. Do NOT relabel a \
+number to the question's scope: if the geography differs (e.g. a GLOBAL \
+cumulative total against a United-States question), set ``location`` to the \
+number's true scope (e.g. "Global"), never the question's region, and note \
+the period (e.g. "cumulative since 2003") in ``summary``. A sub-national \
+figure (one state/district) keeps its sub-national ``location`` and is NOT \
+the national total. A weekly / "new this week" increment must say so in \
+``summary``; it is NOT the cumulative total.
+9. CONFIDENCE reflects SCOPE-MATCH, not textual presence. Set ``confidence`` \
+by how well the fact's metric/geography/time-window match the question, NOT \
+by whether the number appears in the text. A number present verbatim but of \
+uncertain or mismatched scope gets LOW confidence (<= 0.5). Reserve high \
+confidence (> 0.85) for numbers whose metric, geography, and window clearly \
+match the question.
+10. COUNT BASIS. For every case/death-type metric, set ``count_basis`` to \
+exactly one of: ``cumulative`` (a running total to date — "cumulative total", \
+"since the start", "to date", "so far"), ``incident`` (new counts during a \
+period — "new", "reported this week", "in January"), ``active`` (currently \
+active/ongoing — "active cases", "currently under isolation"), ``prevalence`` \
+(point-prevalent cases), or ``unknown``. This is the KIND of number, \
+independent of its value. Do NOT guess: if the chunk gives no explicit cue, \
+use ``unknown``. Ratios and rates that are not counts (e.g. \
+``case_fatality_ratio``, ``reproductive_number``) use ``unknown``.
+11. TIME WINDOW. Set ``time_window`` to the reporting period ONLY for \
+``incident`` counts and ONLY when the chunk states it: ``day``, ``week``, \
+``month``, or ``year``; otherwise ``unknown``. Cumulative, active, and \
+prevalence counts always use ``unknown`` (they have no window). This \
+complements rule 8: a weekly increment is ``count_basis=incident``, \
+``time_window=week`` — and still note "new this week" in ``summary``.
+12. SURVEILLANCE METHOD. Set ``surveillance_method`` to a surveillance or \
+ascertainment method ONLY when it is explicitly stated (e.g. "laboratory \
+surveillance", "syndromic surveillance", "enhanced surveillance", "passive \
+reporting"). Otherwise set it to null. NEVER infer it.
+13. DATA QUALITY. Set ``data_quality`` to a short verbatim-ish note ONLY when \
+the chunk explicitly states a caveat about how the numbers relate to reality: \
+under-reporting ("likely underreported", "true number is higher"), limited \
+testing/ascertainment ("testing capacity limited", "many mild cases not \
+captured"), reporting lag/delay, a suspected-vs-confirmed definition issue, or \
+a surveillance/case-definition change. Otherwise set it to null. Do NOT infer \
+under-reporting from a number alone, and do NOT restate the metric here — this \
+field is only for an explicit data-quality statement present in the text.
+14. Be aware of cognitive biases that affect information processing:
    - Anchoring: do not over-weight the first number you encounter.
    - Availability: rare dramatic events are not necessarily more likely.
    - Overconfidence: if the chunk is ambiguous, lower your confidence.
@@ -161,8 +203,14 @@ EXTRACTION_JSON_SCHEMA: dict = {
                     "metric_name": {"type": ["string", "null"]},
                     "metric_value": {"type": ["number", "null"]},
                     "metric_unit": {"type": ["string", "null"]},
+                    # count_basis / time_window are non-nullable strings with an
+                    # explicit "unknown" member rather than nullable enums: under
+                    # OpenAI strict json-schema a nullable enum must also list
+                    # null, and "unknown" already expresses "not stated" more
+                    # legibly downstream. surveillance_method stays nullable
+                    # free-text (no controlled vocabulary).
                     "count_basis": {
-                        "type": ["string", "null"],
+                        "type": "string",
                         "enum": [
                             "cumulative",
                             "incident",
@@ -172,18 +220,11 @@ EXTRACTION_JSON_SCHEMA: dict = {
                         ],
                     },
                     "time_window": {
-                        "type": ["string", "null"],
-                        "enum": [
-                            "day",
-                            "week",
-                            "month",
-                            "year",
-                            "unknown",
-                        ],
+                        "type": "string",
+                        "enum": ["day", "week", "month", "year", "unknown"],
                     },
-                    "surveillance_method": {
-                        "type": ["string", "null"],
-                    },
+                    "surveillance_method": {"type": ["string", "null"]},
+                    "data_quality": {"type": ["string", "null"]},
                     "event_date": {"type": ["string", "null"]},
                     "summary": {"type": ["string", "null"]},
                     "quote": {"type": "string"},
@@ -199,6 +240,7 @@ EXTRACTION_JSON_SCHEMA: dict = {
                     "count_basis",
                     "time_window",
                     "surveillance_method",
+                    "data_quality",
                     "event_date",
                     "summary",
                     "quote",

--- a/bioscancast/tests/fixtures/insight/extraction_traps.py
+++ b/bioscancast/tests/fixtures/insight/extraction_traps.py
@@ -1,0 +1,575 @@
+"""Labeled trap-set for diagnosing the insight stage's "lurch" failure.
+
+The historical-replay benchmark traced its recurring single-cutoff
+trajectory "lurches" to the insight stage extracting a *bad number* and
+filing it as an observed count. Two concrete examples surfaced in the
+historical-replay benchmark:
+
+* a **projection** ("one in 20 simulations projected an outbreak
+  exceeding 10,000 cases") filed as ``confirmed_cases=10000``;
+* a **wrong-scope** real number (``confirmed_cases=903`` at confidence
+  1.0) that is not a plausible US human-case count for the window.
+
+These are *different* mechanisms — one needs a representational slot for
+non-observed values, the other needs scope-aware reasoning and honest
+confidence — so "add a projected bucket" fixes only the first. This
+module is the instrument that tells them apart: a small set of
+``(chunk, question, expectation)`` cases plus a pure-Python scorer that
+runs over the records a real extractor produces and reports how each
+trap was handled.
+
+The scorer is **forward-compatible** with the planned ``value_basis``
+field: it reads ``getattr(record, "value_basis", None)`` so the same
+harness measures the pre-fix failure rate today and the post-fix
+improvement once the schema/prompt change lands.
+
+No network or LLM calls happen here — this file is data + pure functions.
+``scripts/eval_extraction_traps.py`` and
+``bioscancast/tests/test_insight_extraction_traps.py`` drive it.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import List, Optional, Sequence, Tuple
+
+from bioscancast.schemas import Document, DocumentChunk, InsightRecord
+from bioscancast.stages.filtering.models import ForecastQuestion
+
+
+# Event types that represent an *observed* count in the current schema.
+# Filing a projected or wrong-scope number under one of these (with an
+# observed ``value_basis``) is the core failure the trap-set detects.
+OBSERVED_COUNT_EVENT_TYPES = frozenset({"case_count", "death_count"})
+
+
+# ---------------------------------------------------------------------------
+# Trap / expectation data model
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class TrapValue:
+    """A number planted in a chunk that a correct extractor must NOT treat
+    as an observed, question-scoped count.
+
+    Each flag encodes one way the value can be mishandled. A correct
+    extraction may legitimately extract the value *with the right framing*
+    (e.g. a projection tagged as projected, a global figure tagged
+    global) or omit it entirely — both count as "handled". Only the
+    specific mishandling described by the set flags is a failure.
+    """
+
+    value: float
+    issue: str
+    """Short mechanism label: 'projection' | 'offscope_global' |
+    'weekly' | 'subnational'."""
+
+    must_not_be_observed_count: bool = False
+    """The value must not appear as an observed count event
+    (``case_count``/``death_count`` with an observed ``value_basis``).
+    Set for projections/modeled figures."""
+
+    must_not_be_scoped_to_region: bool = False
+    """The value must not be extracted as an observed count whose
+    ``iso_country_code`` equals the question's region. Set for figures
+    that belong to a different geographic scope (e.g. a global cumulative
+    total against a US question)."""
+
+    must_retain_qualifier: Tuple[str, ...] = ()
+    """If the value is extracted, at least one of these tokens must appear
+    in ``location``/``summary``/``metric_name``/``metric_unit`` so the
+    figure cannot be misread as the question-relevant total. Set for
+    weekly-vs-cumulative and sub-national-vs-national traps."""
+
+    expected_basis: Optional[str] = None
+    """The ``value_basis`` a correct (post-fix) extractor should assign,
+    e.g. ``"projected"``. Used only for the post-fix basis-accuracy
+    metric; ignored when the field is absent."""
+
+
+@dataclass(frozen=True)
+class ExtractionTrap:
+    """One labeled extraction case: a chunk + question + expectations."""
+
+    label: str
+    document: Document
+    chunk: DocumentChunk
+    question: ForecastQuestion
+    trap_values: Tuple[TrapValue, ...] = ()
+    control_values: Tuple[float, ...] = ()
+    """Numbers that a correct extractor SHOULD surface as observed counts
+    (recall guard — stops a fix that just suppresses everything)."""
+    region_iso: Optional[str] = None
+    """ISO alpha-2 of the question's region, for the scope checks."""
+    notes: str = ""
+
+
+# ---------------------------------------------------------------------------
+# Scoring
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class MishandledValue:
+    value: float
+    issue: str
+    reasons: List[str]
+
+
+@dataclass
+class TrapResult:
+    label: str
+    trap_values_total: int
+    mishandled: List[MishandledValue] = field(default_factory=list)
+    trap_confidences: List[float] = field(default_factory=list)
+    controls_total: int = 0
+    controls_recalled: int = 0
+    basis_present: int = 0
+    basis_correct: int = 0
+
+    @property
+    def ok(self) -> bool:
+        """True when no trap value was mishandled and every control was
+        recalled."""
+        return not self.mishandled and self.controls_recalled == self.controls_total
+
+
+def _matches_value(record: InsightRecord, value: float, tol: float = 0.5) -> bool:
+    mv = record.metric_value
+    return mv is not None and abs(float(mv) - value) <= tol
+
+
+def _is_observed_count(record: InsightRecord) -> bool:
+    """Whether the record presents a number as an observed count.
+
+    Forward-compatible with ``value_basis``: an explicit non-observed
+    basis (e.g. ``"projected"``) means the record is *not* an observed
+    count, so a correctly-tagged projection no longer trips the guard.
+    Pre-fix (no such field) every count-typed record is treated as
+    observed.
+    """
+    basis = getattr(record, "value_basis", None)
+    if basis is not None and basis != "observed":
+        return False
+    return (
+        record.event_type in OBSERVED_COUNT_EVENT_TYPES
+        and record.metric_value is not None
+    )
+
+
+def _scoped_to_region(record: InsightRecord, region_iso: Optional[str]) -> bool:
+    return region_iso is not None and record.iso_country_code == region_iso
+
+
+def _qualifier_present(record: InsightRecord, tokens: Sequence[str]) -> bool:
+    haystack = " ".join(
+        part
+        for part in (
+            record.location,
+            record.summary,
+            record.metric_name,
+            record.metric_unit,
+        )
+        if part
+    ).lower()
+    return any(token.lower() in haystack for token in tokens)
+
+
+def score_extraction(
+    records: Sequence[InsightRecord], trap: ExtractionTrap
+) -> TrapResult:
+    """Score one trap's extraction output against its expectations."""
+    result = TrapResult(
+        label=trap.label,
+        trap_values_total=len(trap.trap_values),
+        controls_total=len(trap.control_values),
+    )
+
+    for tv in trap.trap_values:
+        matches = [r for r in records if _matches_value(r, tv.value)]
+        for r in matches:
+            result.trap_confidences.append(r.confidence)
+            basis = getattr(r, "value_basis", None)
+            if basis is not None:
+                result.basis_present += 1
+                if tv.expected_basis and basis == tv.expected_basis:
+                    result.basis_correct += 1
+
+        reasons: List[str] = []
+        if tv.must_not_be_observed_count and any(
+            _is_observed_count(r) for r in matches
+        ):
+            reasons.append("filed-as-observed-count")
+        if tv.must_not_be_scoped_to_region and any(
+            _is_observed_count(r) and _scoped_to_region(r, trap.region_iso)
+            for r in matches
+        ):
+            reasons.append("mis-scoped-to-region")
+        if (
+            tv.must_retain_qualifier
+            and matches
+            and not any(_qualifier_present(r, tv.must_retain_qualifier) for r in matches)
+        ):
+            reasons.append("qualifier-dropped")
+        if reasons:
+            result.mishandled.append(MishandledValue(tv.value, tv.issue, reasons))
+
+    result.controls_recalled = sum(
+        1
+        for cv in trap.control_values
+        if any(_is_observed_count(r) and _matches_value(r, cv) for r in records)
+    )
+    return result
+
+
+def aggregate(results: Sequence[TrapResult]) -> dict:
+    """Roll trap results up into headline metrics for a diagnosis report."""
+    trap_values_total = sum(r.trap_values_total for r in results)
+    mishandled = [m for r in results for m in r.mishandled]
+    reason_counts = {
+        "filed-as-observed-count": 0,
+        "mis-scoped-to-region": 0,
+        "qualifier-dropped": 0,
+    }
+    for m in mishandled:
+        for reason in m.reasons:
+            reason_counts[reason] = reason_counts.get(reason, 0) + 1
+
+    controls_total = sum(r.controls_total for r in results)
+    controls_recalled = sum(r.controls_recalled for r in results)
+    trap_confidences = [c for r in results for c in r.trap_confidences]
+    basis_present = sum(r.basis_present for r in results)
+    basis_correct = sum(r.basis_correct for r in results)
+
+    return {
+        "traps": len(results),
+        "traps_clean": sum(1 for r in results if r.ok),
+        "trap_values_total": trap_values_total,
+        "trap_values_mishandled": len(mishandled),
+        "false_observed_count": reason_counts["filed-as-observed-count"],
+        "mis_scoped_to_region": reason_counts["mis-scoped-to-region"],
+        "qualifier_dropped": reason_counts["qualifier-dropped"],
+        "control_recall": (
+            controls_recalled / controls_total if controls_total else 1.0
+        ),
+        "controls_recalled": controls_recalled,
+        "controls_total": controls_total,
+        "mean_trap_confidence": (
+            sum(trap_confidences) / len(trap_confidences) if trap_confidences else 0.0
+        ),
+        # Populated only once records carry a ``value_basis`` field.
+        "basis_present": basis_present,
+        "basis_correct": basis_correct,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Trap fixtures
+# ---------------------------------------------------------------------------
+
+
+def _doc(doc_id: str, url: str, domain: str, chunk: DocumentChunk) -> Document:
+    """Minimal single-chunk Document wrapper for a trap chunk."""
+    return Document(
+        id=doc_id,
+        result_id=f"r-{doc_id}",
+        source_url=url,
+        domain=domain,
+        fetched_at=datetime(2026, 1, 31, 12, 0, 0),
+        document_type="html",
+        status="success",
+        title=doc_id,
+        chunks=[chunk],
+    )
+
+
+# --- Question reused by the H5N1 traps (matches the BFG q1/q3 framing) ---
+
+_Q_H5N1_US_CASES = ForecastQuestion(
+    id="trap-h5n1-us-cases",
+    text=(
+        "How many confirmed human cases of H5N1 will be reported in the "
+        "United States by December 2026?"
+    ),
+    created_at=datetime(2026, 1, 31),
+    target_date=datetime(2026, 12, 31),
+    region="United States",
+    pathogen="H5N1",
+    event_type="case_count",
+)
+
+
+# Trap A — projection-as-observed (the live-demo "10,000 cases" case).
+_CHUNK_PROJECTION = DocumentChunk(
+    chunk_id="trap-projection-c0",
+    chunk_index=0,
+    text=(
+        "As of 30 January 2026, 47 confirmed human cases of H5N1 have been "
+        "reported in the United States since 2024. A modeling study published "
+        "this week found that, under a worst-case transmission scenario, one "
+        "in 20 simulations projected an outbreak exceeding 10,000 human cases "
+        "by the end of 2026; the authors stressed these figures are "
+        "hypothetical and not observed counts."
+    ),
+    chunk_type="prose",
+    heading="Situation summary",
+)
+
+TRAP_PROJECTION = ExtractionTrap(
+    label="projection_as_observed",
+    document=_doc(
+        "doc-trap-projection",
+        "https://cdc.gov/bird-flu/projection.html",
+        "cdc.gov",
+        _CHUNK_PROJECTION,
+    ),
+    chunk=_CHUNK_PROJECTION,
+    question=_Q_H5N1_US_CASES,
+    trap_values=(
+        TrapValue(
+            value=10000,
+            issue="projection",
+            must_not_be_observed_count=True,
+            expected_basis="projected",
+        ),
+    ),
+    control_values=(47,),
+    region_iso="US",
+    notes="Projection must not be filed as an observed US human-case count.",
+)
+
+
+# Trap A2 — projection without a "hypothetical" disclaimer (harder).
+# The same projection failure but phrased assertively, the way a careless
+# extractor is most likely to grab it as an observed count. Probes the
+# representational gap directly (Trap A's explicit "not observed counts"
+# cue made it too easy).
+_CHUNK_PROJECTION_HARD = DocumentChunk(
+    chunk_id="trap-projection-hard-c0",
+    chunk_index=0,
+    text=(
+        "CDC modeling released today estimates that, absent additional "
+        "interventions, the United States could see as many as 10,000 human "
+        "H5N1 cases by the end of 2026. As of 30 January 2026, 47 human cases "
+        "have been confirmed nationwide."
+    ),
+    chunk_type="prose",
+    heading="Modeling outlook",
+)
+
+TRAP_PROJECTION_HARD = ExtractionTrap(
+    label="projection_no_disclaimer",
+    document=_doc(
+        "doc-trap-projection-hard",
+        "https://cdc.gov/bird-flu/modeling.html",
+        "cdc.gov",
+        _CHUNK_PROJECTION_HARD,
+    ),
+    chunk=_CHUNK_PROJECTION_HARD,
+    question=_Q_H5N1_US_CASES,
+    trap_values=(
+        TrapValue(
+            value=10000,
+            issue="projection",
+            must_not_be_observed_count=True,
+            expected_basis="projected",
+        ),
+    ),
+    control_values=(47,),
+    region_iso="US",
+    notes="Assertively-phrased projection; no 'hypothetical' cue.",
+)
+
+
+# Trap B — wrong-scope global cumulative (the "903" case).
+_CHUNK_OFFSCOPE_GLOBAL = DocumentChunk(
+    chunk_id="trap-offscope-c0",
+    chunk_index=0,
+    text=(
+        "Globally, a cumulative total of 903 human cases of avian influenza "
+        "A(H5N1), including 464 deaths, have been reported to WHO from 2003 "
+        "to 2024 across 24 countries. In the United States, human infections "
+        "remain rare and are mostly linked to occupational exposure on dairy "
+        "and poultry farms."
+    ),
+    chunk_type="prose",
+    heading="Global epidemiology",
+)
+
+TRAP_OFFSCOPE_GLOBAL = ExtractionTrap(
+    label="offscope_global_cumulative",
+    document=_doc(
+        "doc-trap-offscope",
+        "https://who.int/h5n1/global-summary.html",
+        "who.int",
+        _CHUNK_OFFSCOPE_GLOBAL,
+    ),
+    chunk=_CHUNK_OFFSCOPE_GLOBAL,
+    question=_Q_H5N1_US_CASES,
+    trap_values=(
+        TrapValue(
+            value=903,
+            issue="offscope_global",
+            must_not_be_scoped_to_region=True,
+            must_retain_qualifier=("global", "globally", "world", "2003", "who"),
+        ),
+    ),
+    control_values=(),
+    region_iso="US",
+    notes="903 is a global cumulative-since-2003 figure; must not be tagged US.",
+)
+
+
+# Trap C — weekly-vs-cumulative temporal scope.
+_CHUNK_WEEKLY = DocumentChunk(
+    chunk_id="trap-weekly-c0",
+    chunk_index=0,
+    text=(
+        "As of 12 April 2026, a cumulative total of 1,847 measles cases have "
+        "been reported in Romania this year. During the most recent "
+        "epidemiological week (week 15), 56 new cases were recorded, a "
+        "decline from the previous week."
+    ),
+    chunk_type="prose",
+    heading="Measles surveillance",
+)
+
+_Q_MEASLES_RO = ForecastQuestion(
+    id="trap-measles-ro-cumulative",
+    text=(
+        "Will the cumulative number of measles cases reported in Romania "
+        "exceed 2,000 by 30 April 2026?"
+    ),
+    created_at=datetime(2026, 4, 12),
+    target_date=datetime(2026, 4, 30),
+    region="Romania",
+    pathogen="measles",
+    event_type="case_count",
+)
+
+TRAP_WEEKLY = ExtractionTrap(
+    label="weekly_vs_cumulative",
+    document=_doc(
+        "doc-trap-weekly",
+        "https://ecdc.europa.eu/measles/romania.html",
+        "ecdc.europa.eu",
+        _CHUNK_WEEKLY,
+    ),
+    chunk=_CHUNK_WEEKLY,
+    question=_Q_MEASLES_RO,
+    trap_values=(
+        TrapValue(
+            value=56,
+            issue="weekly",
+            must_retain_qualifier=("week", "weekly", "new"),
+        ),
+    ),
+    control_values=(1847,),
+    region_iso="RO",
+    notes="56 is a weekly increment; must carry the weekly/new qualifier.",
+)
+
+
+# Trap D — sub-national-vs-national.
+_CHUNK_SUBNATIONAL = DocumentChunk(
+    chunk_id="trap-subnational-c0",
+    chunk_index=0,
+    text=(
+        "Texas alone has reported 312 affected herds, the highest of any "
+        "state. Nationwide, USDA has now confirmed H5N1 in a cumulative "
+        "1,043 livestock herds across 16 states as of 30 January 2026."
+    ),
+    chunk_type="prose",
+    heading="Livestock detections",
+)
+
+_Q_H5N1_US_HERDS = ForecastQuestion(
+    id="trap-h5n1-us-herds",
+    text=(
+        "Will H5N1 be confirmed in more than 1,500 US livestock herds by "
+        "June 2026?"
+    ),
+    created_at=datetime(2026, 1, 31),
+    target_date=datetime(2026, 6, 30),
+    region="United States",
+    pathogen="H5N1",
+    event_type="case_count",
+)
+
+TRAP_SUBNATIONAL = ExtractionTrap(
+    label="subnational_vs_national",
+    document=_doc(
+        "doc-trap-subnational",
+        "https://usda.gov/h5n1/herds.html",
+        "usda.gov",
+        _CHUNK_SUBNATIONAL,
+    ),
+    chunk=_CHUNK_SUBNATIONAL,
+    question=_Q_H5N1_US_HERDS,
+    trap_values=(
+        TrapValue(
+            value=312,
+            issue="subnational",
+            must_retain_qualifier=("texas", "state"),
+        ),
+    ),
+    control_values=(1043,),
+    region_iso="US",
+    notes="312 is a Texas subtotal; must not be read as the national figure.",
+)
+
+
+# Trap E — clean observed control (no trap; recall guard).
+_CHUNK_CLEAN = DocumentChunk(
+    chunk_id="trap-clean-c0",
+    chunk_index=0,
+    text=(
+        "On 12 February 2025, the Ministry of Health of Uganda notified WHO of "
+        "an outbreak of Sudan virus disease in Mubende district. As of 15 "
+        "February 2025, a total of 9 confirmed cases including 3 deaths have "
+        "been reported."
+    ),
+    chunk_type="prose",
+    heading="Epidemiological summary",
+)
+
+_Q_SUDAN = ForecastQuestion(
+    id="trap-sudan-outbreak",
+    text=(
+        "Will the Sudan virus outbreak in Uganda exceed 50 confirmed cases "
+        "by March 2025?"
+    ),
+    created_at=datetime(2025, 2, 16),
+    target_date=datetime(2025, 3, 31),
+    region="Uganda",
+    pathogen="Sudan virus",
+    event_type="case_count",
+)
+
+TRAP_CLEAN_CONTROL = ExtractionTrap(
+    label="clean_observed_control",
+    document=_doc(
+        "doc-trap-clean",
+        "https://who.int/don/svd-uganda.html",
+        "who.int",
+        _CHUNK_CLEAN,
+    ),
+    chunk=_CHUNK_CLEAN,
+    question=_Q_SUDAN,
+    trap_values=(),
+    control_values=(9,),
+    region_iso="UG",
+    notes="Genuine observed count; a good extractor must surface it confidently.",
+)
+
+
+ALL_TRAPS: List[ExtractionTrap] = [
+    TRAP_PROJECTION,
+    TRAP_PROJECTION_HARD,
+    TRAP_OFFSCOPE_GLOBAL,
+    TRAP_WEEKLY,
+    TRAP_SUBNATIONAL,
+    TRAP_CLEAN_CONTROL,
+]

--- a/bioscancast/tests/test_insight_count_basis.py
+++ b/bioscancast/tests/test_insight_count_basis.py
@@ -1,0 +1,203 @@
+"""Regression test for the epidemiological count-basis distinction.
+
+This is the deterministic, in-repo version of the count-basis diagnostic:
+"282 cumulative", "282 new this week", and "282 active" are the same
+metric_name/value but epidemiologically different numbers. Before the
+count_basis/time_window fields they flattened into identical structured
+records, with the distinction surviving only in free-text summary. These
+tests pin the structured distinction so it cannot silently regress.
+
+All tests use FakeLLMClient — no network, no real OpenAI import. The fake
+responses stand in for what the (schema-constrained) extractor returns; the
+assertions exercise chunk_extractor's propagation of the new fields.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from bioscancast.llm.base import LLMResponse
+from bioscancast.llm.fake_client import FakeLLMClient
+from bioscancast.schemas import Document, DocumentChunk
+from bioscancast.stages.filtering.models import ForecastQuestion
+from bioscancast.stages.insight.text_extraction.chunk_extractor import extract_facts_from_chunk
+
+
+_QUESTION = ForecastQuestion(
+    id="q-count-basis",
+    text="How many confirmed cases of mpox will be reported in Country X?",
+    created_at=datetime(2026, 7, 3, tzinfo=timezone.utc),
+    region="Country X",
+    pathogen="mpox",
+)
+
+
+def _chunk_and_doc(text: str) -> tuple[DocumentChunk, Document]:
+    chunk = DocumentChunk(
+        chunk_id="c0", chunk_index=0, text=text, chunk_type="prose"
+    )
+    doc = Document(
+        id="d0", result_id="r0", source_url="https://example.org/report",
+        domain="example.org", fetched_at=datetime(2026, 7, 3, tzinfo=timezone.utc),
+        document_type="html", status="success",
+        title="Country X mpox situation report", chunks=[chunk],
+    )
+    return chunk, doc
+
+
+def _response(*, count_basis, time_window, surveillance_method, quote,
+              data_quality=None) -> LLMResponse:
+    return LLMResponse(
+        content={
+            "facts": [
+                {
+                    "event_type": "case_count",
+                    "confidence": 0.9,
+                    "location": "Country X",
+                    "pathogen": "mpox",
+                    "metric_name": "confirmed_cases",
+                    "metric_value": 282,
+                    "metric_unit": "cases",
+                    "count_basis": count_basis,
+                    "time_window": time_window,
+                    "surveillance_method": surveillance_method,
+                    "data_quality": data_quality,
+                    "event_date": "2026-07-03",
+                    "summary": None,
+                    "quote": quote,
+                }
+            ]
+        },
+        input_tokens=200, output_tokens=60, model="gpt-4o-mini", raw_text="{}",
+    )
+
+
+# Same value (282), same metric_name — different epidemiological basis.
+_CASES = {
+    "cumulative": (
+        "As of 3 July 2026, Country X has reported a cumulative total of 282 "
+        "confirmed cases of mpox since the start of the outbreak.",
+        _response(count_basis="cumulative", time_window="unknown",
+                  surveillance_method=None,
+                  quote="a cumulative total of 282 confirmed cases of mpox"),
+    ),
+    "incident": (
+        "During the week of 27 June to 3 July 2026, Country X reported 282 new "
+        "confirmed cases of mpox, according to laboratory surveillance.",
+        _response(count_basis="incident", time_window="week",
+                  surveillance_method="laboratory surveillance",
+                  quote="Country X reported 282 new confirmed cases of mpox"),
+    ),
+    "active": (
+        "As of 3 July 2026, Country X currently has 282 active confirmed cases "
+        "of mpox under isolation.",
+        _response(count_basis="active", time_window="unknown",
+                  surveillance_method=None,
+                  quote="282 active confirmed cases of mpox under isolation"),
+    ),
+}
+
+
+def _extract(label: str):
+    text, response = _CASES[label]
+    chunk, doc = _chunk_and_doc(text)
+    client = FakeLLMClient([response])
+    records, _ = extract_facts_from_chunk(
+        chunk, doc, _QUESTION, client, model="gpt-4o-mini"
+    )
+    assert len(records) == 1, f"{label}: expected one record"
+    return records[0]
+
+
+def test_count_basis_is_preserved_distinctly():
+    """The three snippets share metric_name/value but must differ in
+    count_basis — the flattening the meeting flagged."""
+    cumulative = _extract("cumulative")
+    incident = _extract("incident")
+    active = _extract("active")
+
+    # Same surface metric...
+    for r in (cumulative, incident, active):
+        assert r.metric_name == "confirmed_cases"
+        assert r.metric_value == 282.0
+
+    # ...distinct basis.
+    assert cumulative.count_basis == "cumulative"
+    assert incident.count_basis == "incident"
+    assert active.count_basis == "active"
+    assert len({cumulative.count_basis, incident.count_basis, active.count_basis}) == 3
+
+
+def test_time_window_only_for_incident():
+    """time_window is meaningful only for incident counts."""
+    assert _extract("incident").time_window == "week"
+    assert _extract("cumulative").time_window == "unknown"
+    assert _extract("active").time_window == "unknown"
+
+
+def test_surveillance_method_only_when_stated():
+    """surveillance_method is captured only where explicitly present."""
+    assert _extract("incident").surveillance_method == "laboratory surveillance"
+    assert _extract("cumulative").surveillance_method is None
+    assert _extract("active").surveillance_method is None
+
+
+def test_data_quality_propagates_when_present():
+    """An explicit data-quality caveat is carried onto the record; a plain
+    count leaves it None."""
+    text = (
+        "Officials cautioned the true number is likely higher than the 282 "
+        "confirmed cases, as testing capacity remains limited."
+    )
+    chunk, doc = _chunk_and_doc(text)
+    resp = _response(
+        count_basis="cumulative", time_window="unknown",
+        surveillance_method=None,
+        data_quality="testing capacity limited; true number likely higher",
+        quote="the 282 confirmed cases",
+    )
+    client = FakeLLMClient([resp])
+    records, _ = extract_facts_from_chunk(
+        chunk, doc, _QUESTION, client, model="gpt-4o-mini"
+    )
+    assert records[0].data_quality == "testing capacity limited; true number likely higher"
+    # Clean count -> no caveat.
+    assert _extract("cumulative").data_quality is None
+
+
+def test_fields_default_to_none_when_absent():
+    """Backward compatibility: a response omitting the new keys (e.g. an
+    old fixture) must not raise — the fields fall back to None."""
+    text = (
+        "On 3 July 2026, Country X's Ministry of Health reported 282 confirmed "
+        "cases of mpox."
+    )
+    chunk, doc = _chunk_and_doc(text)
+    legacy = LLMResponse(
+        content={
+            "facts": [
+                {
+                    "event_type": "case_count",
+                    "confidence": 0.8,
+                    "location": "Country X",
+                    "pathogen": "mpox",
+                    "metric_name": "confirmed_cases",
+                    "metric_value": 282,
+                    "metric_unit": "cases",
+                    "event_date": "2026-07-03",
+                    "summary": None,
+                    "quote": "reported 282 confirmed cases of mpox",
+                }
+            ]
+        },
+        input_tokens=100, output_tokens=20, model="gpt-4o-mini", raw_text="{}",
+    )
+    client = FakeLLMClient([legacy])
+    records, _ = extract_facts_from_chunk(
+        chunk, doc, _QUESTION, client, model="gpt-4o-mini"
+    )
+    assert len(records) == 1
+    assert records[0].count_basis is None
+    assert records[0].time_window is None
+    assert records[0].surveillance_method is None
+    assert records[0].data_quality is None

--- a/bioscancast/tests/test_insight_extraction_traps.py
+++ b/bioscancast/tests/test_insight_extraction_traps.py
@@ -1,0 +1,320 @@
+"""Tests for the insight extraction trap-set scorer + a live diagnostic.
+
+Two layers:
+
+1. **Pure-scorer unit tests** (no network) validate that
+   ``score_extraction`` correctly flags each mishandling mode and is
+   forward-compatible with a future ``value_basis`` field. These prove the
+   instrument is sound without needing API keys.
+
+2. **Integration through ``extract_facts_from_chunk``** with a scripted
+   ``FakeLLMClient`` confirms a "bad" model response (projection filed as an
+   observed count) is caught and a "good" one passes.
+
+3. **A ``@pytest.mark.live`` diagnostic** runs the real extractor over the
+   whole trap-set and prints a report. Opt in with ``--live`` and a real
+   ``OPENAI_API_KEY``; choose the model with ``--trap-model`` (default
+   ``gpt-4o-mini``). This is the A2 diagnosis instrument.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from bioscancast.llm.base import LLMResponse
+from bioscancast.llm.fake_client import FakeLLMClient
+from bioscancast.schemas import InsightRecord
+from bioscancast.stages.insight.text_extraction.chunk_extractor import extract_facts_from_chunk
+
+from bioscancast.tests.fixtures.insight.extraction_traps import (
+    ALL_TRAPS,
+    TRAP_PROJECTION,
+    aggregate,
+    score_extraction,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _record(**kwargs) -> InsightRecord:
+    """Build an InsightRecord with sensible defaults for scorer tests."""
+    base = dict(
+        id="ins-test",
+        question_id="q-test",
+        event_type="case_count",
+        confidence=1.0,
+    )
+    base.update(kwargs)
+    return InsightRecord(**base)
+
+
+def _fact(**kwargs) -> dict:
+    """Build a fact dict matching the extraction schema."""
+    fact = {
+        "event_type": "case_count",
+        "confidence": 1.0,
+        "location": None,
+        "pathogen": None,
+        "metric_name": None,
+        "metric_value": None,
+        "metric_unit": None,
+        "event_date": None,
+        "summary": None,
+        "quote": "",
+    }
+    fact.update(kwargs)
+    return fact
+
+
+def _response(facts: list[dict]) -> LLMResponse:
+    return LLMResponse(
+        content={"facts": facts},
+        input_tokens=200,
+        output_tokens=50,
+        model="gpt-4o-mini",
+        raw_text="{}",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Pure-scorer unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_projection_filed_as_observed_is_flagged():
+    records = [_record(metric_value=10000, event_type="case_count",
+                       metric_name="confirmed_cases")]
+    result = score_extraction(records, TRAP_PROJECTION)
+    assert not result.ok
+    assert len(result.mishandled) == 1
+    assert "filed-as-observed-count" in result.mishandled[0].reasons
+    # The (mis)assigned confidence is captured for the calibration metric.
+    assert result.trap_confidences == [1.0]
+
+
+def test_projection_tagged_value_basis_is_not_flagged():
+    """Forward-compat: a projection correctly tagged with value_basis must
+    NOT trip the observed-count guard, even though it's still a case_count."""
+    rec = _record(metric_value=10000, event_type="case_count",
+                  metric_name="confirmed_cases")
+    rec.value_basis = "projected"  # field the fix will add
+    result = score_extraction([rec], TRAP_PROJECTION)
+    assert not result.mishandled
+    assert result.basis_present == 1
+    assert result.basis_correct == 1
+
+
+def test_projection_omitted_is_not_flagged():
+    """Suppressing the projection (no count record for it) is acceptable."""
+    rec = _record(metric_value=None, event_type="other",
+                  summary="A model projected an outbreak exceeding 10,000 cases.")
+    result = score_extraction([rec], TRAP_PROJECTION)
+    assert not result.mishandled
+
+
+def test_control_recall_counts_observed_value():
+    from bioscancast.tests.fixtures.insight.extraction_traps import (
+        TRAP_CLEAN_CONTROL,
+    )
+    records = [_record(metric_value=9, event_type="case_count",
+                       metric_name="confirmed_cases", iso_country_code="UG")]
+    result = score_extraction(records, TRAP_CLEAN_CONTROL)
+    assert result.controls_total == 1
+    assert result.controls_recalled == 1
+    assert result.ok
+
+
+def test_missing_control_is_not_ok():
+    from bioscancast.tests.fixtures.insight.extraction_traps import (
+        TRAP_CLEAN_CONTROL,
+    )
+    result = score_extraction([], TRAP_CLEAN_CONTROL)
+    assert result.controls_recalled == 0
+    assert not result.ok
+
+
+def test_offscope_global_tagged_us_is_flagged():
+    from bioscancast.tests.fixtures.insight.extraction_traps import (
+        TRAP_OFFSCOPE_GLOBAL,
+    )
+    records = [_record(metric_value=903, event_type="case_count",
+                       metric_name="confirmed_cases", iso_country_code="US")]
+    result = score_extraction(records, TRAP_OFFSCOPE_GLOBAL)
+    assert any("mis-scoped-to-region" in m.reasons for m in result.mishandled)
+
+
+def test_offscope_global_tagged_global_is_clean():
+    from bioscancast.tests.fixtures.insight.extraction_traps import (
+        TRAP_OFFSCOPE_GLOBAL,
+    )
+    # Global cumulative kept global (no US iso) and carrying the qualifier.
+    records = [_record(metric_value=903, event_type="case_count",
+                       metric_name="confirmed_cases", iso_country_code=None,
+                       location="Global", summary="cumulative since 2003 reported to WHO")]
+    result = score_extraction(records, TRAP_OFFSCOPE_GLOBAL)
+    assert result.ok
+
+
+def test_weekly_without_qualifier_is_flagged():
+    from bioscancast.tests.fixtures.insight.extraction_traps import TRAP_WEEKLY
+    records = [
+        _record(metric_value=1847, event_type="case_count",
+                metric_name="confirmed_cases", iso_country_code="RO"),
+        _record(metric_value=56, event_type="case_count",
+                metric_name="confirmed_cases", iso_country_code="RO",
+                summary="56 cases reported"),  # no week/new qualifier
+    ]
+    result = score_extraction(records, TRAP_WEEKLY)
+    assert any("qualifier-dropped" in m.reasons for m in result.mishandled)
+
+
+def test_weekly_with_qualifier_is_clean():
+    from bioscancast.tests.fixtures.insight.extraction_traps import TRAP_WEEKLY
+    records = [
+        _record(metric_value=1847, event_type="case_count",
+                metric_name="confirmed_cases", iso_country_code="RO"),
+        _record(metric_value=56, event_type="case_count",
+                metric_name="confirmed_cases", iso_country_code="RO",
+                summary="56 new cases in epidemiological week 15"),
+    ]
+    result = score_extraction(records, TRAP_WEEKLY)
+    assert result.ok
+
+
+def test_subnational_without_state_qualifier_is_flagged():
+    from bioscancast.tests.fixtures.insight.extraction_traps import (
+        TRAP_SUBNATIONAL,
+    )
+    records = [
+        _record(metric_value=1043, event_type="case_count",
+                metric_name="affected_herds", iso_country_code="US"),
+        _record(metric_value=312, event_type="case_count",
+                metric_name="affected_herds", iso_country_code="US"),  # no Texas
+    ]
+    result = score_extraction(records, TRAP_SUBNATIONAL)
+    assert any("qualifier-dropped" in m.reasons for m in result.mishandled)
+    assert result.controls_recalled == 1  # 1043 national still recalled
+
+
+# ---------------------------------------------------------------------------
+# Integration through the real extractor (FakeLLMClient — no network)
+# ---------------------------------------------------------------------------
+
+
+def test_bad_extraction_through_extractor_is_flagged():
+    """A model response that files the projection as confirmed_cases should
+    be produced by the extractor and caught by the scorer."""
+    facts = [
+        _fact(  # control: genuine observed US count
+            event_type="case_count", metric_name="confirmed_cases",
+            metric_value=47, location="United States",
+            quote="47 confirmed human cases of H5N1 have been reported in the United States",
+        ),
+        _fact(  # trap: projection mis-filed as observed
+            event_type="case_count", metric_name="confirmed_cases",
+            metric_value=10000, location="United States",
+            quote="one in 20 simulations projected an outbreak exceeding 10,000 human cases",
+        ),
+    ]
+    client = FakeLLMClient([_response(facts)])
+    records, _ = extract_facts_from_chunk(
+        TRAP_PROJECTION.chunk, TRAP_PROJECTION.document,
+        TRAP_PROJECTION.question, client, model="gpt-4o-mini",
+    )
+    result = score_extraction(records, TRAP_PROJECTION)
+    assert not result.ok
+    assert "filed-as-observed-count" in result.mishandled[0].reasons
+    assert result.controls_recalled == 1  # the 47 still recalled
+
+
+def test_good_extraction_through_extractor_passes():
+    """A response that keeps the observed count and does NOT file the
+    projection as a count passes the scorer."""
+    facts = [
+        _fact(
+            event_type="case_count", metric_name="confirmed_cases",
+            metric_value=47, location="United States",
+            quote="47 confirmed human cases of H5N1 have been reported in the United States",
+        ),
+        _fact(  # projection surfaced as context, not a count
+            event_type="other", metric_name=None, metric_value=None,
+            summary="A modeling study projected an outbreak exceeding 10,000 cases under a worst-case scenario.",
+            quote="one in 20 simulations projected an outbreak exceeding 10,000 human cases",
+        ),
+    ]
+    client = FakeLLMClient([_response(facts)])
+    records, _ = extract_facts_from_chunk(
+        TRAP_PROJECTION.chunk, TRAP_PROJECTION.document,
+        TRAP_PROJECTION.question, client, model="gpt-4o-mini",
+    )
+    result = score_extraction(records, TRAP_PROJECTION)
+    assert result.ok
+
+
+def test_aggregate_smoke():
+    """aggregate() produces the headline metrics over a mixed result set."""
+    bad = [_record(metric_value=10000, event_type="case_count",
+                   metric_name="confirmed_cases")]
+    results = [score_extraction(bad, TRAP_PROJECTION)]
+    agg = aggregate(results)
+    assert agg["traps"] == 1
+    assert agg["false_observed_count"] == 1
+    assert agg["mean_trap_confidence"] == 1.0
+
+
+# ---------------------------------------------------------------------------
+# Live diagnostic (opt-in: --live + OPENAI_API_KEY)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.live
+def test_extraction_traps_live_diagnostic():
+    """Run the real extractor over the trap-set and print a diagnosis report.
+
+    This is a *measurement*, not a pass/fail gate for the current code: it
+    quantifies the lurch failure mode (false-observed rate, trap confidence)
+    so the fix can be chosen and its effect measured. It only asserts the
+    recall guard (a competent extractor must still surface genuine observed
+    counts) and that the harness ran.
+
+    Select the model with ``--trap-model`` (default gpt-4o-mini). Run the
+    strong model too for the issue #26 cheap-vs-strong comparison.
+    """
+    if not os.environ.get("OPENAI_API_KEY"):
+        pytest.skip("needs OPENAI_API_KEY")
+
+    from bioscancast.llm.openai_client import OpenAILLMClient
+
+    model = os.environ.get("TRAP_MODEL", "gpt-4o-mini")
+    client = OpenAILLMClient()
+
+    results = []
+    print(f"\n=== extraction trap-set diagnostic (model={model}) ===")
+    for trap in ALL_TRAPS:
+        records, _ = extract_facts_from_chunk(
+            trap.chunk, trap.document, trap.question, client, model=model,
+        )
+        result = score_extraction(records, trap)
+        results.append(result)
+        flags = ", ".join(
+            f"{m.value:g}:{'/'.join(m.reasons)}" for m in result.mishandled
+        ) or "clean"
+        print(
+            f"  {trap.label:<28} mishandled=[{flags}] "
+            f"controls={result.controls_recalled}/{result.controls_total}"
+        )
+
+    agg = aggregate(results)
+    print("  --- aggregate ---")
+    for k, v in agg.items():
+        print(f"  {k:<24} {v}")
+
+    # Recall guard: genuine observed counts must still be surfaced.
+    assert agg["control_recall"] >= 0.5, (
+        "Extractor is suppressing genuine observed counts — recall too low."
+    )

--- a/scripts/eval_count_basis.py
+++ b/scripts/eval_count_basis.py
@@ -1,0 +1,188 @@
+"""Diagnose the extractor's handling of the epidemiological count-basis
+distinction on a small labeled set.
+
+Runs the real chunk extractor over minimal snippets that share a metric
+name/value but differ in count basis (cumulative / incident / active), plus
+ambiguity and data-quality probes, and reports per case:
+
+- count_basis / time_window / surveillance_method / data_quality,
+- two headline checks plus one observation:
+    * DISTINCT   — the canonical 3-way snippets get 3 different count_basis
+      values (the flattening the meeting flagged);
+    * CAVEAT     — data_quality fires on explicit under-reporting/lag text and
+      stays null on clean counts (no over-population);
+    * BARE-LEAN  — informational: which basis a "reported N cases" sentence
+      with no explicit cue gets. Not pass/fail — live runs show both models
+      lean "cumulative" for "as of ... has reported" phrasing (defensible: it
+      reads as a running total), so the "unknown" fallback rarely triggers on
+      real epidemiological wording. Watch it, don't gate on it.
+
+This is the live counterpart to the deterministic regression test in
+bioscancast/tests/test_insight_count_basis.py, and the count-basis analogue of
+scripts/eval_extraction_traps.py. Not part of CI.
+
+Examples:
+    python scripts/eval_count_basis.py                    # gpt-4o-mini
+    python scripts/eval_count_basis.py --models gpt-4o-mini,gpt-4o
+
+Requires OPENAI_API_KEY (loaded from .env). Cost is a fraction of a cent —
+one small extraction call per case per model.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from datetime import datetime, timezone
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+try:
+    from dotenv import load_dotenv
+
+    load_dotenv()
+except ImportError:  # pragma: no cover
+    pass
+
+for _stream in (sys.stdout, sys.stderr):
+    try:
+        _stream.reconfigure(encoding="utf-8", errors="replace")
+    except (AttributeError, ValueError):  # pragma: no cover
+        pass
+
+from bioscancast.stages.filtering.models import ForecastQuestion  # noqa: E402
+from bioscancast.stages.insight.text_extraction.chunk_extractor import (  # noqa: E402
+    extract_facts_from_chunk,
+)
+from bioscancast.llm.openai_client import OpenAILLMClient  # noqa: E402
+from bioscancast.llm.pricing import estimate_cost  # noqa: E402
+from bioscancast.schemas import Document, DocumentChunk  # noqa: E402
+
+
+_QUESTION = ForecastQuestion(
+    id="eval-count-basis",
+    text="How many confirmed cases of mpox will be reported in Country X?",
+    created_at=datetime(2026, 7, 3, tzinfo=timezone.utc),
+    region="Country X",
+    pathogen="mpox",
+)
+
+# label -> (text, kind). kind drives the headline checks.
+_CASES: dict[str, tuple[str, str]] = {
+    "cumulative": (
+        "As of 3 July 2026, Country X has reported a cumulative total of 282 "
+        "confirmed cases of mpox since the start of the outbreak.",
+        "canonical",
+    ),
+    "incident_week": (
+        "During the week of 27 June to 3 July 2026, Country X reported 282 new "
+        "confirmed cases of mpox, according to laboratory surveillance.",
+        "canonical",
+    ),
+    "active": (
+        "As of 3 July 2026, Country X currently has 282 active confirmed cases "
+        "of mpox under isolation.",
+        "canonical",
+    ),
+    "ambiguous_bare": (
+        "As of 3 July 2026, Country X has reported 282 confirmed cases of mpox.",
+        "ambiguous",
+    ),
+    "caveat_underreport": (
+        "Officials cautioned that the true number of mpox infections in Country "
+        "X is likely far higher than the 282 confirmed cases, as testing "
+        "capacity remains limited and many mild cases go unreported.",
+        "caveat",
+    ),
+    "clean_no_caveat": (
+        "As of 3 July 2026, Country X has reported a cumulative total of 400 "
+        "confirmed cases of mpox since the start of the outbreak.",
+        "clean",
+    ),
+}
+
+
+def _chunk_doc(text: str) -> tuple[DocumentChunk, Document]:
+    chunk = DocumentChunk(chunk_id="c0", chunk_index=0, text=text, chunk_type="prose")
+    doc = Document(
+        id="d0", result_id="r0", source_url="https://example.org/report",
+        domain="example.org", fetched_at=datetime(2026, 7, 3, tzinfo=timezone.utc),
+        document_type="html", status="success",
+        title="Country X mpox situation report",
+        published_date=datetime(2026, 7, 3, tzinfo=timezone.utc), chunks=[chunk],
+    )
+    return chunk, doc
+
+
+def run_model(model: str, max_tokens: int) -> None:
+    client = OpenAILLMClient()
+    tin = tout = 0
+    basis_by_label: dict[str, str | None] = {}
+    dq_by_label: dict[str, str | None] = {}
+
+    print(f"\n=== model: {model} ===")
+    for label, (text, _kind) in _CASES.items():
+        chunk, doc = _chunk_doc(text)
+        records, resp = extract_facts_from_chunk(
+            chunk, doc, _QUESTION, client, model=model, max_tokens=max_tokens
+        )
+        tin += resp.input_tokens
+        tout += resp.output_tokens
+        # Take the record matching the metric (first case_count with a value).
+        rec = next(
+            (r for r in records if r.metric_value is not None), records[0] if records else None
+        )
+        basis_by_label[label] = rec.count_basis if rec else None
+        dq_by_label[label] = rec.data_quality if rec else None
+        if rec is None:
+            print(f"  {label:<20} (no record)")
+        else:
+            print(
+                f"  {label:<20} basis={str(rec.count_basis):<10} "
+                f"window={str(rec.time_window):<8} "
+                f"surv={rec.surveillance_method or '-'} "
+                f"data_quality={rec.data_quality!r}"
+            )
+
+    # ---- headline checks ----
+    canon = [basis_by_label.get(k) for k in ("cumulative", "incident_week", "active")]
+    distinct = len({b for b in canon if b}) == 3
+    caveat_fires = bool(dq_by_label.get("caveat_underreport"))
+    clean_null = dq_by_label.get("clean_no_caveat") in (None, "")
+
+    def mark(ok: bool) -> str:
+        return "PASS" if ok else "FAIL"
+
+    print(f"  --- {model} checks ---")
+    print(f"    DISTINCT (cumulative/incident/active differ): {mark(distinct)} {canon}")
+    print(f"    CAVEAT   (fires on caveat, null on clean):    "
+          f"{mark(caveat_fires and clean_null)} "
+          f"(caveat={dq_by_label.get('caveat_underreport')!r}, "
+          f"clean={dq_by_label.get('clean_no_caveat')!r})")
+    print(f"    BARE-LEAN (info, bare count -> ?):            "
+          f"{basis_by_label.get('ambiguous_bare')!r}")
+    print(f"    est. cost: ${estimate_cost(model, tin, tout):.4f} "
+          f"(in={tin} out={tout})")
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__.split("\n", 1)[0])
+    p.add_argument("--models", default="gpt-4o-mini",
+                   help="Comma-separated models. Default: gpt-4o-mini")
+    p.add_argument("--max-tokens", type=int, default=1024)
+    return p.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv if argv is not None else sys.argv[1:])
+    if not os.environ.get("OPENAI_API_KEY"):
+        print("ERROR: OPENAI_API_KEY not set (shell or .env).", file=sys.stderr)
+        return 2
+    for model in (m.strip() for m in args.models.split(",") if m.strip()):
+        run_model(model, args.max_tokens)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/eval_extraction_prompt_ab.py
+++ b/scripts/eval_extraction_prompt_ab.py
@@ -1,0 +1,173 @@
+"""A/B-test a candidate extraction prompt against the production prompt.
+
+The trap-set diagnosis showed gpt-4o-mini mis-files projections and
+wrong-scope numbers as observed counts at high confidence. This script
+tests the cheapest possible fix:
+*better prompting alone*. It runs the trap-set on gpt-4o-mini with the
+current prompt vs a candidate prompt (observed-vs-projected, scope-match,
+and calibrated-confidence rules), averaged over N runs since extraction
+temperature is non-zero.
+
+If the candidate rescues the cheap model, the win is nearly free and no
+strong-model pass is needed (issue #26). If not, that is the hard evidence
+for a strong pass / model upgrade. Nothing in production changes — the
+candidate prompt is monkeypatched in for the experiment only.
+
+    python scripts/eval_extraction_prompt_ab.py                # gpt-4o-mini, 3 runs
+    python scripts/eval_extraction_prompt_ab.py --runs 5 --model gpt-4o-mini
+
+Requires OPENAI_API_KEY (loaded from .env). ~12*N cheap calls.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+try:
+    from dotenv import load_dotenv
+
+    load_dotenv()
+except ImportError:  # pragma: no cover
+    pass
+
+for _stream in (sys.stdout, sys.stderr):
+    try:
+        _stream.reconfigure(encoding="utf-8", errors="replace")
+    except (AttributeError, ValueError):  # pragma: no cover
+        pass
+
+import bioscancast.stages.insight.text_extraction.prompts as prompts_mod  # noqa: E402
+from bioscancast.stages.insight.text_extraction.chunk_extractor import (  # noqa: E402
+    extract_facts_from_chunk,
+)
+from bioscancast.llm.openai_client import OpenAILLMClient  # noqa: E402
+from bioscancast.tests.fixtures.insight.extraction_traps import (  # noqa: E402
+    ALL_TRAPS,
+    aggregate,
+    score_extraction,
+)
+
+
+# Candidate prompt: the production EXTRACTION_SYSTEM_PROMPT plus three rules
+# targeting the diagnosed failures. Kept verbatim-compatible with the rest
+# of the extractor (same quote rule, canonical metric_names, schema).
+CANDIDATE_SYSTEM_PROMPT = """\
+You are a biosecurity fact extractor.  Your job is to extract \
+structured factual claims from a document chunk that are relevant \
+to a specific forecast question.
+
+RULES:
+1. Extract ONLY facts that are directly stated in or clearly supported \
+by the chunk text.  Do NOT infer, speculate, or use outside knowledge.
+2. For each fact, provide a verbatim quote from the chunk (max 200 \
+characters) that supports the claim.  The quote must be an exact \
+substring of the chunk text and must contain the metric_value (as \
+digits, a number-word, or a clear relative reference). A contextual \
+sentence that mentions the topic but not the figure is NOT acceptable.
+3. If the chunk contains no relevant facts, return an empty facts list.
+4. Do NOT answer the forecast question.  Your job is fact extraction.
+5. For event_date, use the most specific ISO date you can extract \
+(``YYYY-MM-DD`` / ``YYYY-MM`` / ``YYYY``); do not invent a day.
+6. For metric_name, prefer canonical snake_case values when applicable: \
+confirmed_cases, suspected_cases, confirmed_or_probable_cases, deaths, \
+suspected_deaths, hospitalizations, recoveries, vaccinations_administered, \
+vaccine_doses_distributed, affected_herds, affected_animals, \
+new_outbreaks_declared, reproductive_number, case_fatality_ratio. Map \
+"cases"/"reported cases"/"total cases" -> confirmed_cases; "suspected/\
+probable/possible cases" -> suspected_cases; "deaths" -> deaths.
+
+7. OBSERVED vs NON-OBSERVED.  event_type ``case_count`` and ``death_count`` \
+are for OBSERVED, actually-reported counts ONLY.  NEVER assign them to a \
+number that is projected, modeled, forecasted, simulated, estimated, \
+hypothetical, or a target/threshold — even when the number is stated \
+plainly (e.g. "could see as many as 10,000 cases by year-end", "one in 20 \
+simulations projected ..."). For such a number, set event_type ``other``, \
+leave metric_value null, and describe it in ``summary`` (say it is a \
+projection/model output and give its horizon and scenario if stated).
+
+8. SCOPE MATCH.  A number only pertains to the question if its metric, its \
+geography, AND its time window all match the question's.  Do NOT relabel a \
+number to the question's scope:
+   - If the geography differs (e.g. a GLOBAL cumulative total against a \
+United-States question), set ``location`` to the number's true scope \
+(e.g. "Global") — never the question's region — and note the period (e.g. \
+"cumulative since 2003") in ``summary``.
+   - A sub-national figure (one state/district) keeps its sub-national \
+``location``; it is NOT the national total.
+   - A weekly / "new this week" increment must say so in ``summary`` or \
+``metric_name``; it is NOT the cumulative total.
+
+9. CONFIDENCE = SCOPE-MATCH, not textual presence.  Set ``confidence`` by \
+how well the fact's metric/geography/time-window match the question, NOT by \
+whether the number appears in the text.  A number present verbatim but of \
+uncertain or mismatched scope gets LOW confidence (<= 0.5).  Reserve high \
+confidence (> 0.85) for numbers whose metric, geography, and window clearly \
+match the question.
+
+10. Be aware of anchoring, availability, and overconfidence biases; when \
+the chunk is ambiguous, lower your confidence.
+
+OUTPUT: Return a JSON object with a "facts" array.  Each fact has the \
+fields defined in the schema.  Return {"facts": []} if no relevant facts \
+are found."""
+
+
+def _run_once(model: str) -> dict:
+    client = OpenAILLMClient()
+    results = []
+    for trap in ALL_TRAPS:
+        records, _ = extract_facts_from_chunk(
+            trap.chunk, trap.document, trap.question, client, model=model,
+        )
+        results.append(score_extraction(records, trap))
+    return aggregate(results)
+
+
+def _avg(dicts: list[dict], keys: list[str]) -> dict:
+    return {k: sum(d[k] for d in dicts) / len(dicts) for k in keys}
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description=__doc__.split("\n", 1)[0])
+    p.add_argument("--model", default="gpt-4o-mini")
+    p.add_argument("--runs", type=int, default=3)
+    args = p.parse_args(argv if argv is not None else sys.argv[1:])
+
+    if not os.environ.get("OPENAI_API_KEY"):
+        print("ERROR: OPENAI_API_KEY not set (shell or .env).", file=sys.stderr)
+        return 2
+
+    keys = [
+        "false_observed_count", "mis_scoped_to_region", "qualifier_dropped",
+        "mean_trap_confidence", "control_recall", "traps_clean",
+    ]
+    original = prompts_mod.EXTRACTION_SYSTEM_PROMPT
+
+    print(f"Model: {args.model}   runs: {args.runs}\n")
+    print("Running BASELINE (production prompt)...")
+    baseline = _avg([_run_once(args.model) for _ in range(args.runs)], keys)
+
+    print("Running CANDIDATE (augmented prompt)...")
+    prompts_mod.EXTRACTION_SYSTEM_PROMPT = CANDIDATE_SYSTEM_PROMPT
+    try:
+        candidate = _avg([_run_once(args.model) for _ in range(args.runs)], keys)
+    finally:
+        prompts_mod.EXTRACTION_SYSTEM_PROMPT = original
+
+    print(f"\n=== A/B over {args.runs} runs (means; lower mishandling better) ===")
+    print(f"  {'metric':<22}{'baseline':>12}{'candidate':>12}")
+    for k in keys:
+        print(f"  {k:<22}{baseline[k]:>12.2f}{candidate[k]:>12.2f}")
+    print(
+        "\n  (traps_clean is out of "
+        f"{len(ALL_TRAPS)}; control_recall and confidence are 0..1)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/eval_extraction_traps.py
+++ b/scripts/eval_extraction_traps.py
@@ -1,0 +1,152 @@
+"""Diagnose the insight stage's "lurch" failure on a labeled trap-set.
+
+Runs the real chunk extractor over the extraction trap-set
+(``bioscancast/tests/fixtures/insight/extraction_traps.py``) for one or
+more models and prints, per model: how each trap was handled, the records
+it produced, and headline metrics (false-observed rate, mean confidence on
+trap values, control recall). Running the cheap model against the strong
+model is the A2 diagnosis *and* the cheap-vs-strong evidence issue #26
+asks for.
+
+Examples:
+    python scripts/eval_extraction_traps.py                 # gpt-4o-mini vs gpt-4o
+    python scripts/eval_extraction_traps.py --models gpt-4o-mini
+    python scripts/eval_extraction_traps.py --show-records  # print every record
+
+Requires OPENAI_API_KEY (loaded from .env). Cost is a few cents — one
+chunk-extraction call per trap per model.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+try:
+    from dotenv import load_dotenv
+
+    load_dotenv()
+except ImportError:  # pragma: no cover
+    pass
+
+# Windows consoles default to cp1252, which can't encode en-dashes / "≥"
+# that appear in source quotes. Re-encode stdout/stderr as UTF-8 so the
+# report never crashes mid-print (same guard as scripts/demo_forecast.py).
+for _stream in (sys.stdout, sys.stderr):
+    try:
+        _stream.reconfigure(encoding="utf-8", errors="replace")
+    except (AttributeError, ValueError):  # pragma: no cover
+        pass
+
+from bioscancast.stages.insight.text_extraction.chunk_extractor import (  # noqa: E402
+    extract_facts_from_chunk,
+)
+from bioscancast.llm.openai_client import OpenAILLMClient  # noqa: E402
+from bioscancast.tests.fixtures.insight.extraction_traps import (  # noqa: E402
+    ALL_TRAPS,
+    aggregate,
+    score_extraction,
+)
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__.split("\n", 1)[0])
+    p.add_argument(
+        "--models",
+        default="gpt-4o-mini,gpt-4o",
+        help="Comma-separated models to compare. Default: gpt-4o-mini,gpt-4o",
+    )
+    p.add_argument(
+        "--max-tokens", type=int, default=4096,
+        help="Per-call output-token cap (matches InsightConfig).",
+    )
+    p.add_argument(
+        "--show-records", action="store_true",
+        help="Print every extracted record (auditing why a trap tripped).",
+    )
+    return p.parse_args(argv)
+
+
+def _fmt_record(r) -> str:
+    basis = getattr(r, "value_basis", None)
+    basis_str = f" basis={basis}" if basis is not None else ""
+    value = "" if r.metric_value is None else f"{r.metric_value:g}"
+    return (
+        f"      [{r.event_type}] {r.metric_name or '-'}={value} "
+        f"conf={r.confidence:.2f} loc={r.location or r.iso_country_code or '-'}"
+        f"{basis_str}"
+    )
+
+
+def run_model(model: str, max_tokens: int, show_records: bool) -> dict:
+    client = OpenAILLMClient()
+    results = []
+    print(f"\n=== model: {model} ===")
+    for trap in ALL_TRAPS:
+        records, _ = extract_facts_from_chunk(
+            trap.chunk, trap.document, trap.question, client,
+            model=model, max_tokens=max_tokens,
+        )
+        result = score_extraction(records, trap)
+        results.append(result)
+        flags = (
+            ", ".join(
+                f"{m.value:g}:{'/'.join(m.reasons)}" for m in result.mishandled
+            )
+            or "clean"
+        )
+        status = "OK " if result.ok else "!! "
+        print(
+            f"  {status}{trap.label:<28} mishandled=[{flags}] "
+            f"controls={result.controls_recalled}/{result.controls_total}"
+        )
+        if show_records:
+            for r in records:
+                print(_fmt_record(r))
+
+    agg = aggregate(results)
+    print(f"  --- {model} aggregate ---")
+    print(
+        f"    false_observed={agg['false_observed_count']}  "
+        f"mis_scoped={agg['mis_scoped_to_region']}  "
+        f"qualifier_dropped={agg['qualifier_dropped']}  "
+        f"mean_trap_conf={agg['mean_trap_confidence']:.2f}  "
+        f"control_recall={agg['control_recall']:.2f}  "
+        f"clean={agg['traps_clean']}/{agg['traps']}"
+    )
+    return agg
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv if argv is not None else sys.argv[1:])
+    if not os.environ.get("OPENAI_API_KEY"):
+        print("ERROR: OPENAI_API_KEY not set (shell or .env).", file=sys.stderr)
+        return 2
+
+    models = [m.strip() for m in args.models.split(",") if m.strip()]
+    summary: dict[str, dict] = {}
+    for model in models:
+        summary[model] = run_model(model, args.max_tokens, args.show_records)
+
+    if len(models) > 1:
+        print("\n=== comparison (lower mishandling is better) ===")
+        header = f"  {'metric':<22}" + "".join(f"{m:>16}" for m in models)
+        print(header)
+        for key in (
+            "false_observed_count", "mis_scoped_to_region", "qualifier_dropped",
+            "mean_trap_confidence", "control_recall", "traps_clean",
+        ):
+            row = f"  {key:<22}" + "".join(
+                f"{summary[m][key]:>16.2f}" if isinstance(summary[m][key], float)
+                else f"{summary[m][key]:>16}"
+                for m in models
+            )
+            print(row)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Ports the **insight-stage half** of the count-basis / data-quality work plus the observed-vs-projected **"lurch" fix** from `feat/pipeline-tuning` onto the post-refactor `stages/` layout. The two branches share no common ancestor, so this is a manual re-application, not a merge.

This is the first of a small series porting the genuinely-ahead work off `feat/pipeline-tuning`. It is self-contained and unblocked. The forecasting-stage PR (next) depends on the `data_quality` field added here.

## Count-basis schema fixes — two real PR #37 defects
- **Invalid strict-mode schema.** `count_basis`/`time_window` were declared `type: ["string","null"]` with an `enum` that omitted `null`, while both were listed in `required` — contradictory under OpenAI strict json-schema (the model can never legally emit the null the type permits). Switched to non-nullable `string` enums with an explicit `"unknown"` member, so the model always answers and abstains legibly.
- **Missing trailing newline** in `prompts.py`, restored.
- Richer `count_basis`/`time_window`/`surveillance_method` docstrings on `InsightRecord`, keeping `count_basis` (what kind of count) distinct from the separate, deferred `value_basis` axis (observed vs projected, #26).

## `data_quality` — new field, end-to-end in the insight stage
`InsightRecord.data_quality` + extraction schema property + system-prompt rule 13 + propagation in `chunk_extractor`. Captures **explicit** under-reporting / limited-testing / reporting-lag / definition-change caveats (never inferred from a number alone) for the forecasting stage to weigh.

## "Lurch" hardening — system-prompt rules 7–9
- **Rule 7 OBSERVED vs NON-OBSERVED**: projections/models/targets become `event_type=other` with `metric_value=null`, never `case_count`/`death_count`.
- **Rule 8 SCOPE-MATCH**: a number keeps its true geography/window; don't relabel a global cumulative total to a US question's scope.
- **Rule 9 CONFIDENCE tracks scope-match**, not textual presence.

Guards the documented failure where a projection ("could see 10,000 cases") or a wrong-scope real number (`confirmed_cases=903 @ conf 1.0`) was filed as an observed count.

## Tests + harnesses
- `test_insight_count_basis.py` — pins the 3-way basis distinction, window-only-for-incident, surveillance/data_quality propagation, and absent-key backward compat.
- `extraction_traps.py` + `test_insight_extraction_traps.py` — adversarial trap-set (projection, off-scope global, weekly-vs-cumulative, subnational) with a pure-Python scorer and a FakeLLM (offline) integration path; forward-compatible with a future `value_basis`.
- `scripts/eval_count_basis.py`, `eval_extraction_traps.py`, `eval_extraction_prompt_ab.py` — live, opt-in diagnostic harnesses (not run in CI).

## Deliberately excluded
- `value_basis` field (#26) — stays deferred; the trap harness works without it.
- The digest tags + forecast-prompt reasoning that consume these fields live in the forecasting stage and land in the next PR.

## Testing
`pytest bioscancast/tests` → **496 passed, 3 skipped** (was 478/2 on `main`; +18 new tests). Offline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)