### PR TITLE
Extraction: thin-extraction guard + Docling refiner telemetry

### DIFF
--- a/bioscancast/main.py
+++ b/bioscancast/main.py
@@ -45,6 +45,7 @@ from bioscancast.stages.searching.cache import SearchCache
 from bioscancast.stages.searching.pipeline import SearchStagePipeline
 from bioscancast.stages.extraction.config import ExtractionConfig
 from bioscancast.stages.extraction.pipeline import ExtractionPipeline
+from bioscancast.stages.extraction.quality import flag_thin_extractions
 from bioscancast.stages.filtering.config import FILTER_CONFIG
 from bioscancast.stages.filtering.models import ForecastQuestion
 from bioscancast.stages.filtering.pipeline import FilteringPipeline
@@ -385,15 +386,47 @@ def run_pipeline(args: argparse.Namespace) -> InsightRunResult:
         )
         persistence.save_manifest(run_dir, manifest)
 
+        extraction_config = ExtractionConfig()
         with _stage_timer(manifest, "extract"):
-            extraction_pipeline = ExtractionPipeline(as_of_date=question.as_of_date)
+            extraction_pipeline = ExtractionPipeline(
+                config=extraction_config,
+                as_of_date=question.as_of_date,
+            )
             documents = extraction_pipeline.run(filtered_docs)
             persistence.save_documents(run_dir, documents)
         n_ok = sum(1 for d in documents if d.status == "success")
+        # 'success' only means bytes-in + ≥1 chunk; it does NOT mean the
+        # content we cared about was captured. Flag suspiciously-thin
+        # successes (nav/index pages, paywalls, JS-rendered data — #34) so a
+        # silent retrieval miss is visible instead of hiding behind "N/N".
+        thin_warnings = flag_thin_extractions(
+            documents, min_chars=extraction_config.thin_extraction_min_chars
+        )
+        manifest["thin_extractions"] = [w.as_dict() for w in thin_warnings]
+        # Docling refiner telemetry (#17): per-PDF wall-clock / page count /
+        # suspect-table footprint, for the per-page-vs-full-doc decision.
+        # Empty unless PDFs reached the refiner.
+        docling_telemetry = extraction_pipeline.docling_telemetry
+        manifest["docling_refiner"] = [t.as_dict() for t in docling_telemetry]
+        thin_note = f", {len(thin_warnings)} thin" if thin_warnings else ""
+        n_refined = sum(1 for t in docling_telemetry if t.fired)
+        docling_note = (
+            f", docling {n_refined}/{len(docling_telemetry)} PDFs"
+            if docling_telemetry else ""
+        )
         _log_summary(
-            "extract", f"{n_ok}/{len(documents)} success",
+            "extract", f"{n_ok}/{len(documents)} success{thin_note}{docling_note}",
             manifest["stage_timings"]["extract"],
         )
+        for w in thin_warnings:
+            print(f"  ! thin extraction: {w.describe()}", flush=True)
+        for t in docling_telemetry:
+            if t.fired:
+                print(
+                    f"  · docling refined {t.page_count}p in {t.convert_s:.1f}s "
+                    f"({t.n_suspect_tables} suspect tables) {t.source_url}",
+                    flush=True,
+                )
         persistence.save_manifest(run_dir, manifest)
 
         with _stage_timer(manifest, "insight"):

--- a/bioscancast/stages/extraction/config.py
+++ b/bioscancast/stages/extraction/config.py
@@ -11,6 +11,18 @@ class ExtractionConfig:
     pdf_max_pages: int = 100
     chunk_target_tokens: int = 800
     chunk_max_tokens: int = 1500
+
+    thin_extraction_min_chars: int = 500
+    """Char floor below which a 'success' document is flagged as a likely
+    silent-truncation (nav/index page, paywall snippet, or JS-rendered page
+    whose payload never made it into the static scrape).
+
+    Measurement-only: flagging never drops or alters a document. The floor is
+    set from observed run artifacts — across 156 saved docs, every doc below
+    ~500 chars was junk (the who.int emergencies index at 263, a Washington
+    Post paywall snippet at 274; see #34), while no legitimate content doc
+    fell below it. Set to 0 to disable flagging.
+    """
     user_agent: str = (
         "BioScanCast/0.1 (+https://github.com/algorithmicgovernance/BioScanCast)"
     )

--- a/bioscancast/stages/extraction/docling_refiner.py
+++ b/bioscancast/stages/extraction/docling_refiner.py
@@ -14,13 +14,51 @@ from __future__ import annotations
 
 import io
 import logging
-from dataclasses import replace
+import time
+from dataclasses import dataclass, field, replace
 from typing import Any, FrozenSet, List, Optional, Sequence, Tuple
 
 from .config import ExtractionConfig
 from .parsers.base import ParsedContent, SectionContent
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass
+class RefinerTelemetry:
+    """One record per ``refine()`` call (i.e. per PDF that reaches the refiner).
+
+    Captures the inputs issue #17 needs to decide per-page vs full-doc Docling:
+    per-doc wall-clock, page count, and the suspect-table footprint. ``fired``
+    distinguishes calls where Docling actually ran from skips (no trigger /
+    OCR-required). Conversion is the page-scaling cost — ``convert_s`` is the
+    metric ``page_range`` would reduce; ``total_s`` adds the (cheap) merge.
+    """
+
+    source_url: str
+    fired: bool
+    trigger: Optional[str]  # "allowlist" | "heuristic" | None
+    status: str
+    page_count: Optional[int]
+    n_suspect_tables: int
+    suspect_pages: List[int] = field(default_factory=list)
+    convert_s: Optional[float] = None
+    total_s: float = 0.0
+
+    def as_dict(self) -> dict:
+        return {
+            "source_url": self.source_url,
+            "fired": self.fired,
+            "trigger": self.trigger,
+            "status": self.status,
+            "page_count": self.page_count,
+            "n_suspect_tables": self.n_suspect_tables,
+            "suspect_pages": list(self.suspect_pages),
+            "convert_s": (
+                round(self.convert_s, 3) if self.convert_s is not None else None
+            ),
+            "total_s": round(self.total_s, 3),
+        }
 
 
 class DoclingTableRefiner:
@@ -40,6 +78,10 @@ class DoclingTableRefiner:
         self._config = config
         # Allow dependency injection for tests; real construction is lazy.
         self._converter = converter
+        # One RefinerTelemetry per refine() call, in call order. The
+        # extraction pipeline drains this after a run so the orchestrator can
+        # persist it (issue #17: 2-week refiner-time collection).
+        self.telemetry: List[RefinerTelemetry] = []
 
     # ---------- public API ----------
 
@@ -60,8 +102,14 @@ class DoclingTableRefiner:
         Short-circuits to a no-op for OCR-required PDFs — Docling without OCR
         cannot help there.
         """
+        t0 = time.perf_counter()
+
         if parsed.is_partial and parsed.partial_reason == "requires_ocr":
             logger.debug("docling refiner skipped: requires_ocr")
+            self._record(
+                source_url, fired=False, trigger=None, status="skipped_ocr",
+                parsed=parsed, flagged=[], total_s=time.perf_counter() - t0,
+            )
             return parsed
 
         # Always compute broken-table indices: even URL-triggered runs need
@@ -76,19 +124,67 @@ class DoclingTableRefiner:
             source_url, self._config.docling_source_allowlist
         )
         if url_match:
+            trigger = "allowlist"
             logger.info(
                 "docling refiner triggered: source-allowlist hit for %s", source_url
             )
         elif flagged:
+            trigger = "heuristic"
             for _, reason in flagged:
                 logger.info("docling refiner triggered: %s", reason)
         else:
             logger.debug(
                 "docling refiner skipped: no trigger matched for %s", source_url
             )
+            self._record(
+                source_url, fired=False, trigger=None, status="skipped_no_trigger",
+                parsed=parsed, flagged=flagged, total_s=time.perf_counter() - t0,
+            )
             return parsed
 
-        return self._do_refine(parsed, content, broken_indices=broken_indices)
+        refined, convert_s, status = self._do_refine(
+            parsed, content, broken_indices=broken_indices
+        )
+        self._record(
+            source_url, fired=(status == "refined"), trigger=trigger, status=status,
+            parsed=parsed, flagged=flagged, convert_s=convert_s,
+            total_s=time.perf_counter() - t0,
+        )
+        return refined
+
+    def _record(
+        self,
+        source_url: str,
+        *,
+        fired: bool,
+        trigger: Optional[str],
+        status: str,
+        parsed: ParsedContent,
+        flagged: Sequence[Tuple[int, str]],
+        total_s: float,
+        convert_s: Optional[float] = None,
+    ) -> None:
+        suspect_pages = sorted(
+            {
+                parsed.sections[i].page_number
+                for i, _ in flagged
+                if 0 <= i < len(parsed.sections)
+                and parsed.sections[i].page_number is not None
+            }
+        )
+        self.telemetry.append(
+            RefinerTelemetry(
+                source_url=source_url,
+                fired=fired,
+                trigger=trigger,
+                status=status,
+                page_count=parsed.page_count,
+                n_suspect_tables=len(flagged),
+                suspect_pages=suspect_pages,
+                convert_s=convert_s,
+                total_s=total_s,
+            )
+        )
 
     # ---------- internals ----------
 
@@ -98,27 +194,37 @@ class DoclingTableRefiner:
         content: bytes,
         *,
         broken_indices: FrozenSet[int] = frozenset(),
-    ) -> ParsedContent:
+    ) -> Tuple[ParsedContent, Optional[float], str]:
+        """Run Docling and merge its tables back in.
+
+        Returns ``(parsed, convert_s, status)`` where ``convert_s`` is the
+        wall-clock of the Docling ``convert()`` call (None if it never ran)
+        and ``status`` is one of ``refined``, ``converter_unavailable``,
+        ``conversion_failed``, ``no_document``.
+        """
         try:
             converter = self._get_converter()
         except Exception as exc:  # pragma: no cover - construction failures
             logger.warning("docling converter unavailable: %s", exc)
-            return parsed
+            return parsed, None, "converter_unavailable"
 
+        t0 = time.perf_counter()
         try:
             result = converter.convert(content)
         except Exception as exc:
             logger.warning("docling conversion failed: %s", exc)
-            return parsed
+            return parsed, time.perf_counter() - t0, "conversion_failed"
+        convert_s = time.perf_counter() - t0
 
         docling_doc = getattr(result, "document", None)
         if docling_doc is None:
             logger.warning("docling result has no document; leaving parsed unchanged")
-            return parsed
+            return parsed, convert_s, "no_document"
 
-        return _merge_docling_tables_into_parsed(
+        merged = _merge_docling_tables_into_parsed(
             parsed, docling_doc, broken_indices=broken_indices
         )
+        return merged, convert_s, "refined"
 
     def _get_converter(self) -> Any:
         if self._converter is not None:

--- a/bioscancast/stages/extraction/pipeline.py
+++ b/bioscancast/stages/extraction/pipeline.py
@@ -61,6 +61,18 @@ class ExtractionPipeline:
 
         return results
 
+    @property
+    def docling_telemetry(self) -> list:
+        """Per-PDF Docling refiner telemetry accumulated during ``run``.
+
+        Empty when the refiner never ran (no PDFs, or feature flag off).
+        See ``docling_refiner.RefinerTelemetry`` (issue #17).
+        """
+        refiner = self._docling_refiner
+        if refiner is None:
+            return []
+        return list(getattr(refiner, "telemetry", []))
+
     def extract_one(self, filtered_doc: FilteredDocument) -> Document:
         """Fetch, parse, chunk, and return a Document for a single FilteredDocument."""
         doc_id = f"doc-{filtered_doc.result_id}"

--- a/bioscancast/stages/extraction/quality.py
+++ b/bioscancast/stages/extraction/quality.py
@@ -1,0 +1,85 @@
+"""Post-extraction quality guard — flag silent-truncation extractions.
+
+The extraction pipeline marks any fetch that returns bytes and produces at
+least one chunk ``status="success"`` (see ``pipeline.py``), regardless of
+whether the *content that mattered* was actually captured. In practice this
+means a healthy-looking "N/N success" stage line can hide a total retrieval
+miss: a WHO emergencies *index* page (263 chars of nav links), a paywall
+snippet, or a JS-rendered data page whose figures never made it into the
+static scrape (#34, mpox).
+
+This module adds a measurement-only guard: it flags ``success`` documents
+whose extracted text is suspiciously thin so the orchestrator can surface
+them. It never drops or mutates a document — the forecast pipeline sees the
+same inputs whether or not flagging is on.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List
+
+from bioscancast.schemas.document import Document
+
+
+@dataclass(frozen=True)
+class ThinExtractionWarning:
+    """A ``success`` document whose char count fell below the floor."""
+
+    doc_id: str
+    result_id: str
+    domain: str
+    source_url: str
+    document_type: str
+    char_count: int
+    min_chars: int
+
+    def describe(self) -> str:
+        return (
+            f"{self.domain} ({self.char_count} chars < {self.min_chars}) "
+            f"{self.source_url}"
+        )
+
+    def as_dict(self) -> dict:
+        return {
+            "doc_id": self.doc_id,
+            "result_id": self.result_id,
+            "domain": self.domain,
+            "source_url": self.source_url,
+            "document_type": self.document_type,
+            "char_count": self.char_count,
+            "min_chars": self.min_chars,
+            "reason": "thin_extraction",
+        }
+
+
+def flag_thin_extractions(
+    documents: List[Document], *, min_chars: int
+) -> List[ThinExtractionWarning]:
+    """Return a warning for each ``success`` document thinner than ``min_chars``.
+
+    ``min_chars <= 0`` disables flagging (returns an empty list). Failed and
+    partial documents are skipped — their ``error_message`` already records
+    why they're short.
+    """
+    if min_chars <= 0:
+        return []
+
+    warnings: List[ThinExtractionWarning] = []
+    for doc in documents:
+        if doc.status != "success":
+            continue
+        char_count = doc.char_count or 0
+        if char_count < min_chars:
+            warnings.append(
+                ThinExtractionWarning(
+                    doc_id=doc.id,
+                    result_id=doc.result_id,
+                    domain=doc.domain,
+                    source_url=doc.source_url,
+                    document_type=doc.document_type,
+                    char_count=char_count,
+                    min_chars=min_chars,
+                )
+            )
+    return warnings

--- a/bioscancast/tests/test_extraction_quality.py
+++ b/bioscancast/tests/test_extraction_quality.py
@@ -1,0 +1,76 @@
+"""Tests for the thin-extraction guard (bioscancast.stages.extraction.quality)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from bioscancast.stages.extraction.quality import (
+    ThinExtractionWarning,
+    flag_thin_extractions,
+)
+from bioscancast.schemas.document import Document
+
+
+def _make_doc(
+    *,
+    doc_id: str = "doc-r1",
+    result_id: str = "r1",
+    domain: str = "who.int",
+    char_count: int = 263,
+    status: str = "success",
+) -> Document:
+    return Document(
+        id=doc_id,
+        result_id=result_id,
+        source_url=f"https://{domain}/page",
+        domain=domain,
+        fetched_at=datetime.now(timezone.utc),
+        document_type="html",
+        status=status,
+        char_count=char_count,
+    )
+
+
+def test_flags_thin_success_document():
+    # The #34 culprit: WHO emergencies index, 263 chars, reported success.
+    docs = [_make_doc(char_count=263)]
+    warnings = flag_thin_extractions(docs, min_chars=500)
+    assert len(warnings) == 1
+    w = warnings[0]
+    assert isinstance(w, ThinExtractionWarning)
+    assert w.domain == "who.int"
+    assert w.char_count == 263
+    assert w.as_dict()["reason"] == "thin_extraction"
+
+
+def test_does_not_flag_substantial_document():
+    docs = [_make_doc(char_count=3576)]
+    assert flag_thin_extractions(docs, min_chars=500) == []
+
+
+def test_boundary_is_exclusive():
+    # Exactly at the floor is not flagged; one below is.
+    assert flag_thin_extractions([_make_doc(char_count=500)], min_chars=500) == []
+    assert len(flag_thin_extractions([_make_doc(char_count=499)], min_chars=500)) == 1
+
+
+def test_skips_non_success_documents():
+    # Failed/partial docs already carry an error_message; don't double-flag.
+    docs = [
+        _make_doc(char_count=10, status="failed"),
+        _make_doc(char_count=10, status="partial"),
+    ]
+    assert flag_thin_extractions(docs, min_chars=500) == []
+
+
+def test_handles_none_char_count():
+    docs = [_make_doc(char_count=None)]  # type: ignore[arg-type]
+    warnings = flag_thin_extractions(docs, min_chars=500)
+    assert len(warnings) == 1
+    assert warnings[0].char_count == 0
+
+
+def test_disabled_when_floor_non_positive():
+    docs = [_make_doc(char_count=1)]
+    assert flag_thin_extractions(docs, min_chars=0) == []
+    assert flag_thin_extractions(docs, min_chars=-1) == []


### PR DESCRIPTION
Ports the extraction-observability guards from `feat/pipeline-tuning`. Independent of the other port PRs (branches off `main`).

## Why
The extract stage logs "N/N success" whenever bytes came back and ≥1 chunk was produced — but that hides **total retrieval misses** where the "content" is a nav/index page, a paywall, or a JS-rendered dashboard with no numbers (the q7/q8 mpox class behind #34). These guards make such misses visible; they never drop or mutate a document.

## Changes
- **`stages/extraction/quality.py`** (new) — `flag_thin_extractions()` returns a `ThinExtractionWarning` for every `success` document whose `char_count` is below `thin_extraction_min_chars` (default 500; `<=0` disables). Measurement only.
- **`docling_refiner.py`** — `RefinerTelemetry` captures per-PDF wall-clock, page count, and suspect-table footprint (one record per `refine()` call) to inform the per-page-vs-full-doc refiner decision (#17). `_do_refine` now returns `(parsed, convert_s, status)`; **refinement behavior is unchanged** (single caller, verified).
- **`pipeline.py`** — `docling_telemetry` property exposes the accumulated records.
- **`config.py`** — `thin_extraction_min_chars` knob.
- **`main.py`** — the extract stage runs the guard, records `thin_extractions` + `docling_refiner` into the manifest, and prints per-item thin/refined lines.

## Note on `main.py`
`python -m bioscancast.main` is currently broken at import on `main` (and therefore on this branch) by a **pre-existing** missing `load_question_by_id` in `evaluation/loaders.py` — a casualty of the `stages/` refactor, unrelated to this feature and **fixed by the forecasting-stage PR (#46)**. This PR's extract-stage wiring is verified import-clean via a shim, and the module + full test suite pass offline. Once #46 (or its loader fix) lands, the orchestrator imports and this wiring is live.

## Testing
`pytest bioscancast/tests` → **484 passed, 2 skipped** (was 478/2 on `main`; +6 `test_extraction_quality.py` tests). `_do_refine`'s new return tuple checked against its sole caller.

🤖 Generated with [Claude Code](https://claude.com/claude-code)