### PR TITLE
Filter: relevance beats authority in the keep decision; guarantee official recall (#44)

### DIFF
--- a/bioscancast/stages/filtering/config.py
+++ b/bioscancast/stages/filtering/config.py
@@ -32,10 +32,16 @@ FILTER_CONFIG = {
         "ngo": 0.6,
         "unknown": 0.35,
     },
+    # keyword_overlap (topical relevance) carries the most weight so a
+    # reputable-but-off-topic source can't clear the keep threshold on domain
+    # authority alone (#44). domain (generic tier authority) was lowered from
+    # 0.20 -> 0.10 and folded into keyword_overlap (0.40 -> 0.50); official
+    # authority is preserved via official_bonus (unchanged) plus the
+    # unconditional official keep in heuristics.compute_heuristic_decisions.
     "heuristic_weights": {
-        "keyword_overlap": 0.40,
+        "keyword_overlap": 0.50,
         "freshness": 0.20,
-        "domain": 0.20,
+        "domain": 0.10,
         "official_bonus": 0.20,
     },
     # Lowered from 0.72 to 0.65 after q7/q12 live runs showed filter

--- a/bioscancast/stages/filtering/heuristics.py
+++ b/bioscancast/stages/filtering/heuristics.py
@@ -72,8 +72,12 @@ def compute_priority_score(
         FILTER_CONFIG["heuristic_weights"],
     )
 
-    # Blend in credibility as an additional stabilizer.
-    return 0.75 * score + 0.25 * credibility_score
+    # Blend in credibility as an additional stabilizer. Kept low (0.15) so a
+    # reputable-but-off-topic source cannot clear the keep threshold on
+    # authority alone (#44); topical keyword-overlap dominates the decision.
+    # Official-source recall does NOT rely on this term — officials are kept
+    # unconditionally in the heuristic loop below.
+    return 0.85 * score + 0.15 * credibility_score
 
 
 def make_decision(
@@ -156,7 +160,17 @@ def heuristic_filter(
         if result.file_type == "pdf":
             reason_codes.append("pdf_candidate")
 
-        if priority_score >= FILTER_CONFIG["heuristic_keep_threshold"]:
+        passes_threshold = priority_score >= FILTER_CONFIG["heuristic_keep_threshold"]
+        # Official domains are kept unconditionally so official-source recall
+        # stays 1.0 (the #13 sweep property) independent of the priority
+        # weights. This decouples the recall guarantee from the credibility
+        # blend, so that blend can be lowered (#44) without dropping a
+        # low-keyword-overlap official (e.g. a terse WHO DON) below threshold.
+        if passes_threshold or result.is_official_domain:
+            keep_reason = (
+                "passed_heuristic_threshold" if passes_threshold
+                else "official_recall_guarantee"
+            )
             keep_list.append(
                 make_decision(
                     result=result,
@@ -165,7 +179,7 @@ def heuristic_filter(
                     relevance_score=relevance_score,
                     credibility_score=credibility_score,
                     priority_score=priority_score,
-                    reason_codes=reason_codes + ["passed_heuristic_threshold"],
+                    reason_codes=reason_codes + [keep_reason],
                 )
             )
         elif priority_score >= FILTER_CONFIG["heuristic_borderline_threshold"]:

--- a/bioscancast/tests/test_heuristics.py
+++ b/bioscancast/tests/test_heuristics.py
@@ -1,21 +1,94 @@
 from datetime import datetime
 
-from bioscancast.stages.filtering.heuristics import is_low_value_page
-from bioscancast.stages.filtering.models import SearchResult
+import pytest
+
+from bioscancast.stages.filtering.heuristics import (
+    compute_priority_score,
+    heuristic_filter,
+    is_low_value_page,
+)
+from bioscancast.stages.filtering.models import ForecastQuestion, SearchResult
 
 
-def test_low_value_page_detected():
-    result = SearchResult(
+def _mk_result(**overrides) -> SearchResult:
+    base = dict(
         id="1",
         question_id="q1",
         query_id="s1",
         engine="google",
-        url="https://example.com/login",
+        url="https://example.com/article",
         canonical_url=None,
         domain="example.com",
-        title="Login",
-        snippet="Sign in here",
+        title="Some headline",
+        snippet="Some body text",
         rank=1,
         retrieved_at=datetime.utcnow(),
     )
+    base.update(overrides)
+    return SearchResult(**base)
+
+
+def test_low_value_page_detected():
+    result = _mk_result(url="https://example.com/login", title="Login", snippet="Sign in here")
     assert is_low_value_page(result) is True
+
+
+# ---------------------------------------------------------------------------
+# Relevance-vs-credibility keep decision (#44)
+# ---------------------------------------------------------------------------
+
+
+def test_priority_credibility_weight_is_low():
+    """The credibility blend is 0.15, not the old 0.25 — two results identical
+    except credibility differ by exactly 0.15 * delta (#44)."""
+    result = _mk_result(freshness_score=0.5, domain_score=0.5, is_official_domain=False)
+    low = compute_priority_score(result, relevance_score=0.4, credibility_score=0.2)
+    high = compute_priority_score(result, relevance_score=0.4, credibility_score=0.8)
+    assert high - low == pytest.approx(0.15 * (0.8 - 0.2))
+
+
+def test_topical_relevance_outranks_generic_authority():
+    """A non-official on-topic source outscores a non-official off-topic one
+    that only has domain/credibility authority (#44). Under the old weights
+    (keyword_overlap 0.40, domain 0.20, credibility 0.25) the ranking was the
+    other way around."""
+    on_topic = _mk_result(freshness_score=0.5, domain_score=0.35, is_official_domain=False)
+    off_topic_authority = _mk_result(
+        freshness_score=0.5, domain_score=0.9, is_official_domain=False
+    )
+    p_on_topic = compute_priority_score(
+        on_topic, relevance_score=0.8, credibility_score=0.35
+    )
+    p_authority = compute_priority_score(
+        off_topic_authority, relevance_score=0.2, credibility_score=0.9
+    )
+    assert p_on_topic > p_authority
+
+
+def test_official_source_kept_even_when_priority_below_threshold():
+    """Official-source recall stays 1.0: an official document with no topical
+    overlap and no freshness (priority well below the keep threshold) is still
+    kept, tagged ``official_recall_guarantee`` (#44 guardrail / #13)."""
+    question = ForecastQuestion(
+        id="q1",
+        text="How many cases of pathogen Y in country X?",
+        created_at=datetime.utcnow(),
+        pathogen="pathogen Y",
+        region="country X",
+    )
+    official = _mk_result(
+        url="https://who.int/emergencies/don-456",
+        domain="who.int",
+        title="Weekly bulletin",
+        snippet="Routine administrative note.",
+        source_tier="official",
+        is_official_domain=True,
+        domain_score=0.0,
+        freshness_score=0.0,
+    )
+    keep_list, borderline_list, reject_list = heuristic_filter([official], question)
+    kept_ids = {d.result_id for d in keep_list}
+    assert official.id in kept_ids
+    kept = next(d for d in keep_list if d.result_id == official.id)
+    assert "official_recall_guarantee" in kept.reason_codes
+    assert kept.priority_score < 0.65  # kept despite being below threshold


### PR DESCRIPTION
Closes the mechanism in #44. Independent of the other port PRs (branches off `main`). This one is not a port from `feat/pipeline-tuning` (neither side did it) — it's the follow-up you flagged.

## Problem (#44)
The heuristic keep decision let a reputable-but-off-topic source clear the threshold on authority alone. Keyword-overlap sat at an effective **0.30** weight (`0.75 * 0.40`), while credibility entered at a flat **0.25** on top of generic domain authority. During the #3/#4/#13 review an H5N1 run kept an off-topic CBS transcript admitted on credibility, not relevance — the acknowledged trade-off of the #30 Tier-3 promotions.

## The catch that shapes the fix
The current design **relies on** the `0.25·credibility` term to float low-relevance *official* sources over the bar: a zero-relevance official scores `0.6875` and only clears `0.65` because of that term. So naively lowering the credibility blend — #44's literal ask — would drop terse official sources (e.g. a short WHO DON) and break the #13 official-recall=1.0 guarantee.

So the fix decouples recall from the tuning first:

- **`heuristic_filter`: keep official domains unconditionally** (reason code `official_recall_guarantee`). Official recall is now 1.0 *structurally*, independent of the priority weights.
- **`compute_priority_score`: credibility blend `0.25 → 0.15`.** Safe now that officials don't depend on it.
- **`config` `heuristic_weights`: `keyword_overlap 0.40 → 0.50`, `domain 0.20 → 0.10`** (freshness/official_bonus unchanged; still sums to 1.0). Topical overlap now dominates; generic tier authority is halved.

## Tests
- `test_priority_credibility_weight_is_low` — pins the 0.15 blend.
- `test_topical_relevance_outranks_generic_authority` — a non-official on-topic source now outscores a non-official off-topic high-authority one; **under the old weights the ranking was reversed**.
- `test_official_source_kept_even_when_priority_below_threshold` — an official doc well below threshold is still kept via `official_recall_guarantee`.

`pytest bioscancast/tests` → **481 passed, 2 skipped** (was 478/2; +3 tests). Existing official-keep / integration tests still green.

## Caveat
The exact weights are **directional** — reduce authority's pull without dropping topical recall. Final values should be confirmed with a live filter recall/precision sweep on real runs (as in #13); I can't run that here. The **structural official-recall guarantee holds regardless of the weights**, so this is safe to land and tune later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)