### PR TITLE
Fix: dashboard-injected sources bypass the low-value-page screen

### DIFF
--- a/bioscancast/stages/filtering/heuristics.py
+++ b/bioscancast/stages/filtering/heuristics.py
@@ -111,25 +111,13 @@ def heuristic_filter(
     reject_list: list[FilterDecision] = []
 
     for result in search_results:
-        if is_low_value_page(result):
-            reject_list.append(
-                make_decision(
-                    result=result,
-                    keep=False,
-                    stage="heuristic",
-                    relevance_score=0.0,
-                    credibility_score=0.0,
-                    priority_score=0.0,
-                    reason_codes=["low_value_page"],
-                )
-            )
-            continue
-
-        # Dashboard-injected results are hand-curated in
-        # ``bioscancast/datasets/biosecurity_sources.py``; they bypass the
-        # keyword-overlap-driven heuristic which structurally undervalues
-        # their generic titles. See issue #14 and live-run data on q7/q12
-        # where 4/4 injected dashboards had keyword_overlap == 0.000.
+        # Dashboard-injected results are hand-curated in ``sources.yaml``; they
+        # bypass the keyword-overlap-driven heuristic which structurally
+        # undervalues their generic titles (issue #14: q7/q12 had 4/4 injected
+        # dashboards at keyword_overlap == 0.000). This bypass runs BEFORE the
+        # low-value-page screen so a curated URL is never dropped by it — e.g.
+        # ``polioeradication.org/about-polio/polio-this-week/`` matches the
+        # "about" low-value keyword yet is the authoritative polio dashboard.
         if result.retrieval_reason == "dashboard_lookup":
             relevance_score = compute_heuristic_relevance(result, question)
             credibility_score = compute_heuristic_credibility(result)
@@ -142,6 +130,20 @@ def heuristic_filter(
                     credibility_score=credibility_score,
                     priority_score=1.0,
                     reason_codes=["dashboard_lookup_bypass"],
+                )
+            )
+            continue
+
+        if is_low_value_page(result):
+            reject_list.append(
+                make_decision(
+                    result=result,
+                    keep=False,
+                    stage="heuristic",
+                    relevance_score=0.0,
+                    credibility_score=0.0,
+                    priority_score=0.0,
+                    reason_codes=["low_value_page"],
                 )
             )
             continue

--- a/bioscancast/tests/test_heuristics.py
+++ b/bioscancast/tests/test_heuristics.py
@@ -92,3 +92,29 @@ def test_official_source_kept_even_when_priority_below_threshold():
     kept = next(d for d in keep_list if d.result_id == official.id)
     assert "official_recall_guarantee" in kept.reason_codes
     assert kept.priority_score < 0.65  # kept despite being below threshold
+
+
+def test_dashboard_lookup_survives_low_value_url():
+    """A curated dashboard whose URL trips the low-value screen (an ``/about``
+    path like GPEI's ``about-polio/polio-this-week``) must still be kept: the
+    ``dashboard_lookup`` bypass runs *before* the low-value-page check, so
+    injected sources are never dropped by URL-shape heuristics."""
+    question = ForecastQuestion(
+        id="q1",
+        text="How many wild poliovirus type 1 cases in 2026?",
+        created_at=datetime.utcnow(),
+        pathogen="poliovirus",
+    )
+    dashboard = _mk_result(
+        url="https://polioeradication.org/about-polio/polio-this-week/",
+        domain="polioeradication.org",
+        retrieval_reason="dashboard_lookup",
+    )
+    # Sanity: on its own this URL would be dropped by the low-value screen.
+    assert is_low_value_page(dashboard) is True
+
+    keep_list, _borderline, reject_list = heuristic_filter([dashboard], question)
+    assert dashboard.id in {d.result_id for d in keep_list}
+    assert dashboard.id not in {d.result_id for d in reject_list}
+    kept = next(d for d in keep_list if d.result_id == dashboard.id)
+    assert "dashboard_lookup_bypass" in kept.reason_codes


### PR DESCRIPTION
## What

Curated dashboard sources (`retrieval_reason == "dashboard_lookup"`) are supposed to bypass the filter heuristics, but in `heuristic_filter` the `is_low_value_page()` screen ran **before** the bypass. Any injected dashboard whose URL matched a low-value keyword was rejected outright — e.g. GPEI's `polioeradication.org/about-polio/polio-this-week/` trips the `/about` keyword — leaving its question with **zero survivors** and no evidence.

## Fix

Move the `dashboard_lookup` bypass to the top of the per-result loop, ahead of the low-value-page check. Curated sources are hand-picked, so URL-shape heuristics should never drop them.

## Test

Adds `test_dashboard_lookup_survives_low_value_url`: asserts a dashboard-injected result with an `/about` URL is (a) flagged by `is_low_value_page` on its own, yet (b) kept by `heuristic_filter` with `dashboard_lookup_bypass`.

Full suite: 547 passed, 3 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
