### PR TITLE
Deferred review items from PRs #52/#57 (issues #58, #59, #60)

### DIFF
--- a/bioscancast/stages/extraction/custom_scrapers/_who_hub_common.py
+++ b/bioscancast/stages/extraction/custom_scrapers/_who_hub_common.py
@@ -61,6 +61,47 @@ def _parse_date(text: str) -> Optional[datetime]:
         return None
 
 
+def _select_item_pdf(isoup: BeautifulSoup, item_url: str, kw: str) -> Optional[str]:
+    """Pick the epidemiological-update PDF from a WHO item page.
+
+    An item page can link several PDFs (annexes, translations, briefs), so
+    taking the first ``.pdf`` blindly can extract the wrong document (issue
+    #59). Score candidates by how strongly they look like the situation
+    report/epidemiological update and prefer the highest scorer, falling back
+    to the first PDF in document order so behaviour is unchanged when nothing
+    is distinguishable.
+    """
+    best_url: Optional[str] = None
+    best_score = -1
+    for idx, a in enumerate(isoup.find_all("a", href=True)):
+        cand = urljoin(item_url, a["href"])
+        low = cand.lower()
+        if ".pdf" not in low:
+            continue
+        text = a.get_text(" ", strip=True).lower()
+
+        score = 0
+        # The Docling allowlist and the cumulative tables live on the
+        # ``situation-reports`` path — strongest signal.
+        if "situation-report" in low:
+            score += 4
+        if "epidemiological-update" in low or "epidemiological update" in text:
+            score += 3
+        if kw in low or kw in text:
+            score += 2
+        # WHO serves the real report PDFs from the CDN host.
+        if urlparse(low).netloc.endswith("cdn.who.int"):
+            score += 1
+
+        # Strictly-greater keeps the first candidate on ties, preserving the
+        # previous "first PDF" fallback for indistinguishable pages.
+        if score > best_score:
+            best_score = score
+            best_url = cand
+
+    return best_url
+
+
 def _get(url: str, cfg: ExtractionConfig) -> Optional[curl_requests.Response]:
     try:
         return curl_requests.get(
@@ -124,12 +165,7 @@ def fetch_who_hub_latest_pdf(
         return None
     isoup = BeautifulSoup(item.text, "html.parser")
 
-    pdf_url = None
-    for a in isoup.find_all("a", href=True):
-        cand = urljoin(item_url, a["href"])
-        if ".pdf" in cand.lower():
-            pdf_url = cand
-            break
+    pdf_url = _select_item_pdf(isoup, item_url, kw)
     if not pdf_url:
         return None
 

--- a/bioscancast/stages/extraction/custom_scrapers/ecdc_chikungunya.py
+++ b/bioscancast/stages/extraction/custom_scrapers/ecdc_chikungunya.py
@@ -45,19 +45,54 @@ _REPORT_URL = "https://chik-weekly.ecdc.europa.eu/"
 # "this section will remain empty" between seasons; also the announce sentence.
 _EMPTY_MARKERS = ("will remain empty", "will begin once the first")
 
-# "<n> countr(y|ies) in Europe have reported cases of chikungunya"
+# "<n> countr(y|ies) in Europe have/has reported cases of chikungunya".
+# Accepts singular "has reported" (issue #61, PR #62) and a one- or two-word
+# number token so compound tens like "twenty-one" are captured rather than
+# clipped to the trailing unit (issue #60).
 _REPORT_SENTENCE = re.compile(
-    r"(\w+)\s+countr(?:y|ies)\s+in\s+Europe\s+(?:have|has)\s+reported\s+cases\s+of\s+chikungunya",
+    r"([A-Za-z]+(?:[-\s][A-Za-z]+)?|\d+)\s+countr(?:y|ies)\s+in\s+Europe\s+"
+    r"(?:have|has)\s+reported\s+cases\s+of\s+chikungunya",
     re.IGNORECASE,
 )
 # "France (788)" / "Czechia (12)" — a country name followed by a case count.
 _COUNTRY_PAIR = re.compile(r"([A-Z][A-Za-zÀ-ſ'’.\- ]*?)\s*\(([\d, ]+)\)")
 
-_NUM_WORDS = {
+# EU/EEA membership is 30 countries, so the stated count can plausibly reach the
+# twenties. Cover 0–19, the tens, and compound tens+unit ("twenty-seven").
+_ONES = {
     "no": 0, "zero": 0, "one": 1, "two": 2, "three": 3, "four": 4, "five": 5,
-    "six": 6, "seven": 7, "eight": 8, "nine": 9, "ten": 10, "eleven": 11,
-    "twelve": 12,
+    "six": 6, "seven": 7, "eight": 8, "nine": 9,
 }
+_TEENS = {
+    "ten": 10, "eleven": 11, "twelve": 12, "thirteen": 13, "fourteen": 14,
+    "fifteen": 15, "sixteen": 16, "seventeen": 17, "eighteen": 18, "nineteen": 19,
+}
+_TENS = {"twenty": 20, "thirty": 30}
+
+
+def _word_to_int(phrase: str) -> int | None:
+    """Convert a number word/phrase to an int, or None if not recognized.
+
+    Evaluates the rightmost number expression so incidental leading words don't
+    defeat the lookup, and handles compound tens ("twenty-one" / "twenty one").
+    """
+    parts = phrase.strip().lower().replace("-", " ").split()
+    if not parts:
+        return None
+    if parts[-1].isdigit():
+        return int(parts[-1])
+    if (
+        len(parts) >= 2
+        and parts[-2] in _TENS
+        and parts[-1] in _ONES
+        and 0 < _ONES[parts[-1]] < 10
+    ):
+        return _TENS[parts[-2]] + _ONES[parts[-1]]
+    last = parts[-1]
+    for table in (_ONES, _TEENS, _TENS):
+        if last in table:
+            return table[last]
+    return None
 
 
 def _strip_tags(raw: str) -> str:
@@ -107,14 +142,27 @@ def _parse(text: str):
         tail = re.split(r"This week|\. [A-Z]", tail, maxsplit=1)[0]
         pairs = [(n.strip(), c.replace(" ", "").replace(",", ""))
                  for n, c in _COUNTRY_PAIR.findall(tail)]
-        token = sentence.group(1).lower()
-        stated = _NUM_WORDS.get(token)
-        if stated is None and token.isdigit():
-            stated = int(token)
-        count = stated if stated is not None else len(pairs)
-        # Prefer the enumerated list when it disagrees and is non-empty.
-        if pairs and count != len(pairs):
+        stated = _word_to_int(sentence.group(1))
+        if stated is None and not pairs:
+            # The sentence asserts reporting countries but we can neither parse
+            # the number word nor enumerate pairs — don't fabricate a confident
+            # undercount (0). Fall back to the generic fetch instead (issue #60).
+            logger.info(
+                "ECDC chikungunya: unrecognized count word %r with no enumerable "
+                "pairs; falling back to generic fetch.",
+                sentence.group(1),
+            )
+            return None
+        if stated is None:
             count = len(pairs)
+        elif pairs and len(pairs) > stated:
+            # Enumeration reveals more countries than the prose states — trust the
+            # larger evidence rather than undercount.
+            count = len(pairs)
+        else:
+            # Trust the explicit prose count; a shorter/incomplete pair list must
+            # not drag it down (issue #60).
+            count = stated
         return count, pairs
     if any(mk in text.lower() for mk in _EMPTY_MARKERS):
         return 0, []

--- a/bioscancast/stages/searching/source_lookup.py
+++ b/bioscancast/stages/searching/source_lookup.py
@@ -7,6 +7,7 @@ as the current dashboard lookup, but reads entries from sources.yaml.
 from __future__ import annotations
 
 import logging
+import re
 import uuid
 from datetime import datetime, timezone
 from functools import lru_cache
@@ -53,6 +54,13 @@ _PATHOGEN_ALIASES: dict[str, str] = {
     "wpv1": "polio",
 }
 
+# An explicit influenza A subtype like "H5N5" / "H5N8" (but not "H5N1").
+# Used to stop the broad `h5` / `h5nx` / "avian influenza" aliases from
+# silently funnelling a non-H5N1 subtype into the H5N1 curated source set
+# (issue #58). Bare "h5" and "h5nx" (unspecified N) are intentionally left to
+# resolve to h5n1 as the best-available curated set.
+_H5_SUBTYPE_RE = re.compile(r"h5n(\d+)")
+
 
 @lru_cache(maxsize=1)
 def _load_sources_yaml() -> dict[str, Any]:
@@ -72,11 +80,20 @@ def _resolve_pathogen_key(pathogen: str, family_block: dict[str, Any]) -> str | 
     if key in _PATHOGEN_ALIASES and _PATHOGEN_ALIASES[key] in family_block:
         return _PATHOGEN_ALIASES[key]
 
+    # A text that names an explicit H5 subtype other than H5N1 must not be
+    # aliased into the h5n1 source set by substring matching (issue #58).
+    _m = _H5_SUBTYPE_RE.search(key)
+    non_h5n1_subtype = _m is not None and _m.group(1) != "1"
+
     for alias, canon in _PATHOGEN_ALIASES.items():
         if alias in key and canon in family_block:
+            if non_h5n1_subtype and canon == "h5n1":
+                continue
             return canon
 
     matches = [k for k in family_block if k in key]
+    if non_h5n1_subtype:
+        matches = [k for k in matches if k != "h5n1"]
     if matches:
         return max(matches, key=len)
 

--- a/bioscancast/tests/test_dashboard_lookup.py
+++ b/bioscancast/tests/test_dashboard_lookup.py
@@ -114,3 +114,19 @@ class TestResolvePathogenKey:
         assert _resolve_pathogen_key("bird flu", respiratory) == "h5n1"  # alias
         assert _resolve_pathogen_key("marburg virus disease", hemorrhagic) == "marburg"  # substring
         assert _resolve_pathogen_key("unknownvirus123", hemorrhagic) is None
+
+    def test_bare_h5_and_h5nx_resolve_to_h5n1(self):
+        # Unspecified-N inputs intentionally fall back to the h5n1 curated set.
+        cfg = _load_sources_yaml()
+        respiratory = cfg["specific_pathogen_sources"]["respiratory"]
+        assert _resolve_pathogen_key("h5", respiratory) == "h5n1"
+        assert _resolve_pathogen_key("h5nx", respiratory) == "h5n1"
+        assert _resolve_pathogen_key("avian influenza", respiratory) == "h5n1"
+
+    def test_non_h5n1_subtypes_do_not_resolve_to_h5n1(self):
+        # Explicit non-H5N1 H5 subtypes must not be silently routed to the
+        # H5N1 source set (issue #58).
+        cfg = _load_sources_yaml()
+        respiratory = cfg["specific_pathogen_sources"]["respiratory"]
+        for subtype in ("h5n5", "h5n8", "h5n2", "avian influenza a(h5n5)"):
+            assert _resolve_pathogen_key(subtype, respiratory) != "h5n1", subtype

--- a/bioscancast/tests/test_ecdc_chikungunya_scraper.py
+++ b/bioscancast/tests/test_ecdc_chikungunya_scraper.py
@@ -90,3 +90,53 @@ def test_handles_singular_has_reported():
     assert "1 EU/EEA country have reported locally-acquired" in html
     assert "France (1)" in html
     assert "2026" in html
+
+
+# --- issue #60: number words beyond twelve, and undercount guards -----------
+
+def _sentence(count_word: str, tail: str = "") -> str:
+    return (
+        "<html><body><p>Seasonal surveillance of chikungunya virus disease in the "
+        f"EU/EEA. In 2026, {count_word} countries in Europe have reported cases of "
+        f"chikungunya virus disease{tail}.</p></body></html>"
+    )
+
+
+def test_large_number_word_without_pairs():
+    # "fifteen" exceeds the old twelve ceiling; with no enumerable pairs the
+    # stated prose number must still be honoured (issue #60).
+    result = ecdc_chikungunya.fetch(_PAGE, html_getter=_getter(_sentence("fifteen")))
+    assert "15 EU/EEA countries have reported" in _html(result)
+
+
+def test_compound_number_word():
+    result = ecdc_chikungunya.fetch(_PAGE, html_getter=_getter(_sentence("twenty-one")))
+    assert "21 EU/EEA countries have reported" in _html(result)
+
+
+def test_incomplete_pairs_do_not_drag_down_stated_count():
+    # Prose states five but only two pairs are enumerable; the count must not be
+    # silently undercounted to two (issue #60).
+    result = ecdc_chikungunya.fetch(
+        _PAGE,
+        html_getter=_getter(_sentence("five", ": France (788) and Italy (384)")),
+    )
+    html = _html(result)
+    assert "5 EU/EEA countries have reported" in html
+    assert "France (788)" in html and "Italy (384)" in html
+
+
+def test_enumeration_reveals_more_than_stated():
+    # If the enumerated list is larger than the stated number, trust the list.
+    result = ecdc_chikungunya.fetch(
+        _PAGE,
+        html_getter=_getter(_sentence("two", ": France (1), Italy (2), Spain (3)")),
+    )
+    assert "3 EU/EEA countries have reported" in _html(result)
+
+
+def test_unrecognized_count_word_without_pairs_falls_back():
+    # An unparseable count word with nothing to enumerate must fall back rather
+    # than fabricate a confident zero (issue #60).
+    result = ecdc_chikungunya.fetch(_PAGE, html_getter=_getter(_sentence("several")))
+    assert result is None

--- a/bioscancast/tests/test_who_hub_scraper.py
+++ b/bioscancast/tests/test_who_hub_scraper.py
@@ -1,0 +1,110 @@
+"""Tests for the shared WHO situation-hub scraper (``_who_hub_common``).
+
+All offline: the network boundary ``_get`` is monkeypatched to return canned
+hub / item / PDF responses.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from bs4 import BeautifulSoup
+
+from bioscancast.stages.extraction.custom_scrapers import _who_hub_common
+from bioscancast.stages.extraction.custom_scrapers._who_hub_common import (
+    _select_item_pdf,
+    fetch_who_hub_latest_pdf,
+)
+
+
+class FakeResponse:
+    """Minimal stand-in for a curl_cffi Response used by ``_get``."""
+
+    def __init__(self, *, text: str = "", content: bytes = b"", status_code: int = 200,
+                 url: str = "https://example.com"):
+        self.text = text
+        self.content = content
+        self.status_code = status_code
+        self.url = url
+
+
+# ---------------------------------------------------------------------------
+# _select_item_pdf — the issue #59 regression surface
+# ---------------------------------------------------------------------------
+
+class TestSelectItemPdf:
+    def _soup(self, html: str) -> BeautifulSoup:
+        return BeautifulSoup(html, "html.parser")
+
+    def test_prefers_situation_report_over_first_pdf(self):
+        # An annex PDF appears first in document order; the situation report
+        # must still be chosen (issue #59).
+        html = """
+        <a href="https://cdn.who.int/media/docs/annex-map.pdf">Annex: map</a>
+        <a href="https://cdn.who.int/media/docs/situation-reports/cholera-update.pdf">
+            Epidemiological update
+        </a>
+        """
+        chosen = _select_item_pdf(self._soup(html), "https://who.int/item", "cholera")
+        assert chosen.endswith("situation-reports/cholera-update.pdf")
+
+    def test_prefers_keyword_pdf_over_translation(self):
+        html = """
+        <a href="https://cdn.who.int/media/docs/brief-fr.pdf">Version française</a>
+        <a href="https://cdn.who.int/media/docs/cholera-epi-update.pdf">Report</a>
+        """
+        chosen = _select_item_pdf(self._soup(html), "https://who.int/item", "cholera")
+        assert chosen.endswith("cholera-epi-update.pdf")
+
+    def test_falls_back_to_first_pdf_when_indistinguishable(self):
+        # No situation-report / keyword signal on either link: keep the first,
+        # preserving the pre-fix behaviour.
+        html = """
+        <a href="https://cdn.who.int/media/docs/doc-a.pdf">Document A</a>
+        <a href="https://cdn.who.int/media/docs/doc-b.pdf">Document B</a>
+        """
+        chosen = _select_item_pdf(self._soup(html), "https://who.int/item", "cholera")
+        assert chosen.endswith("doc-a.pdf")
+
+    def test_returns_none_when_no_pdf(self):
+        html = '<a href="https://who.int/item/other">Related item</a>'
+        assert _select_item_pdf(self._soup(html), "https://who.int/item", "cholera") is None
+
+
+# ---------------------------------------------------------------------------
+# fetch_who_hub_latest_pdf — end-to-end with the wrong-PDF trap
+# ---------------------------------------------------------------------------
+
+class TestFetchWhoHubLatestPdf:
+    def test_selects_situation_report_pdf_end_to_end(self, monkeypatch):
+        hub_html = """
+        <a href="/publications/m/item/cholera-update-30-June-2026">
+            Cholera epidemiological update, 30 June 2026
+        </a>
+        """
+        item_html = """
+        <a href="https://cdn.who.int/media/docs/annex-map.pdf">Annex: map</a>
+        <a href="https://cdn.who.int/media/docs/situation-reports/cholera.pdf">
+            Epidemiological update
+        </a>
+        """
+        pdf_bytes = b"%PDF-1.7 fake"
+
+        def fake_get(url, cfg):
+            if url.endswith(".pdf"):
+                return FakeResponse(content=pdf_bytes, url=url)
+            if "/publications/" in url:
+                return FakeResponse(text=item_html, url=url)
+            return FakeResponse(text=hub_html, url=url)
+
+        monkeypatch.setattr(_who_hub_common, "_get", fake_get)
+
+        result = fetch_who_hub_latest_pdf(
+            "https://who.int/emergencies/cholera",
+            "cholera",
+            as_of_date=datetime(2026, 7, 1, tzinfo=timezone.utc),
+        )
+        assert result is not None
+        assert result.content_type == "application/pdf"
+        assert result.content_bytes == pdf_bytes
+        assert result.url.endswith("situation-reports/cholera.pdf")


### PR DESCRIPTION
Groups the deferred, non-blocking review comments from #52 and #57 that were logged as follow-up issues. Each is a targeted matching/parser tightening with regression tests; no behaviour change on the happy paths.

## #58 — H5 alias matching too broad
`source_lookup.py` aliased `h5` → `h5n1` by **substring**, so any text containing `h5` (e.g. `H5N5`, `H5N8`) resolved to the H5N1 curated source set. Made the aliasing subtype-aware: an explicit non-H5N1 H5 subtype no longer routes to `h5n1`, while bare `h5` / `h5nx` (unspecified N) still do.

## #59 — WHO hub scraper could pick the wrong PDF
`_who_hub_common.py` took the **first** `.pdf` link on an item page (annex/translation/brief risk). Added `_select_item_pdf()` which scores candidates — `situation-reports` path, `epidemiological-update`, hub keyword, `cdn.who.int` host — and keeps first-in-document-order on ties, so behaviour is unchanged on indistinguishable pages.

## #60 — ECDC chikungunya number-word undercount
`ecdc_chikungunya.py` only knew number words up to twelve and let an incomplete pair list silently undercount. Now:
- extends number words through the tens incl. compound forms (`twenty-one`), and widens the sentence regex to capture a two-word number token;
- stops a shorter/incomplete pair list from overriding a confidently-stated prose count (only trusts the enumeration when it reveals *more*);
- falls back explicitly (not a fabricated `0`) when the count word is unparseable with no pairs.

## Tests
Regression tests added for all three: non-H5N1 subtypes + bare-`h5`/`h5nx`; multi-PDF WHO item pages (annex-first, translation, indistinguishable fallback, no-PDF) + end-to-end fetch; large/compound number words, incomplete pairs, enumeration-exceeds-stated, and the unparseable-word fallback. Full relevant sweep: 250 passed, 2 skipped (live-network).

## Notes
- **#61** (singular "has reported") was fixed by external PR #62; this branch was rebased on top of it and the shared `_REPORT_SENTENCE` line is resolved to the union of both changes (widened number capture + `have|has`).
- The dead-`urlparse`-import comment on #53 needs no change — it's now used by the #59 fix.

Fixes #58, #59, #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)