### PR TITLE
feat: pathogen-first source routing (#41)

### DIFF
--- a/bioscancast/stages/searching/pipeline.py
+++ b/bioscancast/stages/searching/pipeline.py
@@ -20,7 +20,10 @@ from bioscancast.stages.filtering.models import ForecastQuestion, SearchResult
 from bioscancast.stages.filtering.utils import keyword_overlap_score
 from bioscancast.stages.searching.backends.base import RawSearchResult, SearchBackend
 from bioscancast.stages.searching.cache import SearchCache
-from bioscancast.stages.searching.source_lookup import lookup_yaml_sources
+from bioscancast.stages.searching.source_lookup import (
+    lookup_pathogen_sources,
+    lookup_yaml_sources,
+)
 from bioscancast.stages.searching.date_recovery import recover_published_date
 from bioscancast.stages.searching.query_decomposition import (
     SubQuery,
@@ -226,18 +229,48 @@ class SearchStagePipeline:
             historical_roleplay=self._historical_roleplay,
         )
 
-        source_route = route_sources(question, self._llm)
+        # 2. Inject curated sources.
+        #
+        # Routing policy (issue #41): default/general sources are injected
+        # ONLY when no pathogen-specific sources are available. The structured
+        # ``question.pathogen`` field is the primary, deterministic gate; the
+        # LLM route is a backup for pathogen-unset / unrecognised questions.
+        #
+        #   (a) Pathogen-first: resolve question.pathogen against every family.
+        #       On a hit, inject those curated sources and skip general.
+        #   (b) LLM backup: only if (a) is empty, ask route_sources() to pick a
+        #       route. An unresolved pathogen-family route yields nothing (we no
+        #       longer flatten a whole family), falling through to (c).
+        #   (c) General baseline: the last-resort route when nothing above
+        #       produced pathogen-specific sources.
+        yaml_results = lookup_pathogen_sources(question)
+        if yaml_results:
+            logger.info(
+                "Pathogen-first injection: %d curated source(s) for pathogen=%r",
+                len(yaml_results),
+                question.pathogen,
+            )
+        else:
+            source_route = route_sources(question, self._llm)
+            yaml_results = lookup_yaml_sources(question, source_route)
+            if not yaml_results and source_route != "general_sources":
+                logger.info(
+                    "Route %r yielded no sources; falling back to general_sources",
+                    source_route,
+                )
+                source_route = "general_sources"
+                yaml_results = lookup_yaml_sources(question, source_route)
+            logger.info(
+                "No pathogen-specific sources; LLM backup route=%s produced %d result(s)",
+                source_route,
+                len(yaml_results),
+            )
 
         logger.info(
-            "Decomposed into %d sub-queries (route=%s)",
+            "Decomposed into %d sub-queries; injected %d curated source(s)",
             len(sub_queries),
-            source_route,
+            len(yaml_results),
         )
-
-        # 2. Inject YAML lookups
-        yaml_results = lookup_yaml_sources(question, source_route)
-
-        logger.info("YAML lookup produced %d results", len(yaml_results))
 
         all_results: list[SearchResult] = list(yaml_results)
         seen_canonical: set[str] = {

--- a/bioscancast/stages/searching/source_lookup.py
+++ b/bioscancast/stages/searching/source_lookup.py
@@ -105,6 +105,53 @@ def _resolve_yaml_tier(entry: dict[str, Any], domain: str) -> tuple[int, float, 
     source_tier = get_tier_label(domain.lower(), tier_num)
     return tier_num, domain_score, source_tier
 
+def _iter_family_blocks(cfg: dict[str, Any]) -> list[tuple[str, dict[str, Any]]]:
+    """Yield (family_name, family_block) for every well-formed family."""
+    families = cfg.get("specific_pathogen_sources", {})
+    if not isinstance(families, dict):
+        return []
+    return [
+        (name, block)
+        for name, block in families.items()
+        if isinstance(block, dict)
+    ]
+
+
+def resolve_pathogen_entries(question: ForecastQuestion) -> list[dict[str, Any]]:
+    """Deterministically resolve pathogen-specific entries from ``question.pathogen``.
+
+    Scans *every* family for the question's pathogen (rather than trusting an
+    LLM to pick the family first) and returns the matching source entries.
+    Returns ``[]`` when the pathogen is unset or resolves in no family — the
+    caller then falls back to LLM routing / general sources.
+
+    Entries are de-duplicated by ``id``/``url``: ``h5n1`` is intentionally
+    mirrored under both ``respiratory`` and ``animal_spillover`` in the YAML,
+    so a cross-family scan would otherwise return each H5N1 source twice.
+    """
+    if not question.pathogen:
+        return []
+
+    cfg = _load_sources_yaml()
+    entries: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for _family, family_block in _iter_family_blocks(cfg):
+        pathogen_key = _resolve_pathogen_key(question.pathogen, family_block)
+        source_list = family_block.get(pathogen_key) if pathogen_key else None
+        if not isinstance(source_list, list):
+            continue
+        for entry in source_list:
+            if not isinstance(entry, dict):
+                continue
+            dedup_key = str(entry.get("id") or entry.get("url") or "").strip().lower()
+            if dedup_key and dedup_key in seen:
+                continue
+            if dedup_key:
+                seen.add(dedup_key)
+            entries.append(entry)
+    return entries
+
+
 def _resolve_entries(question: ForecastQuestion, source_route: str) -> list[dict[str, Any]]:
     """Return the YAML entries for the requested route."""
     cfg = _load_sources_yaml()
@@ -131,12 +178,24 @@ def _resolve_entries(question: ForecastQuestion, source_route: str) -> list[dict
     if pathogen_key and isinstance(family_block.get(pathogen_key), list):
         return family_block[pathogen_key]
 
-    # Fallback: flatten everything under the selected family.
-    entries: list[dict[str, Any]] = []
-    for source_list in family_block.values():
-        if isinstance(source_list, list):
-            entries.extend(source_list)
-    return entries
+    # Unresolved pathogen under this family: return nothing rather than
+    # flattening the whole family. Flattening would inject wrong-pathogen
+    # dashboards (e.g. a Lassa question routed to `hemorrhagic` picking up
+    # ebola + marburg case counts the insight stage could misread). The
+    # caller falls back to general_sources instead. (issue #41, finding #1)
+    return []
+
+
+def lookup_pathogen_sources(question: ForecastQuestion) -> List[SearchResult]:
+    """Deterministic pathogen-first injection.
+
+    Resolves ``question.pathogen`` against every family (no LLM routing) and
+    returns the curated sources as SearchResults. Returns ``[]`` when the
+    pathogen is unset or unrecognised, signalling the caller to fall back to
+    LLM routing / general sources. Shares the historical-replay / Wayback
+    behaviour of :func:`lookup_yaml_sources`.
+    """
+    return _entries_to_results(question, resolve_pathogen_entries(question))
 
 
 def lookup_yaml_sources(question: ForecastQuestion, source_route: str) -> List[SearchResult]:
@@ -149,7 +208,18 @@ def lookup_yaml_sources(question: ForecastQuestion, source_route: str) -> List[S
     at-or-before the cutoff and emits a SearchResult pointing at the
     snapshot. Entries with no pre-cutoff snapshot are suppressed.
     """
-    entries = _resolve_entries(question, source_route)
+    return _entries_to_results(question, _resolve_entries(question, source_route))
+
+
+def _entries_to_results(
+    question: ForecastQuestion, entries: list[dict[str, Any]]
+) -> List[SearchResult]:
+    """Convert resolved YAML entries into SearchResults.
+
+    In historical-replay mode (``question.as_of_date`` set) each URL is
+    rewritten to its closest Wayback snapshot at-or-before the cutoff, and
+    entries with no pre-cutoff snapshot are suppressed.
+    """
     if not entries:
         return []
 

--- a/bioscancast/tests/test_dashboard_lookup.py
+++ b/bioscancast/tests/test_dashboard_lookup.py
@@ -2,7 +2,9 @@ from datetime import datetime, timezone
 
 from bioscancast.stages.filtering.models import ForecastQuestion
 from bioscancast.stages.searching.source_lookup import (
+    lookup_pathogen_sources,
     lookup_yaml_sources,
+    resolve_pathogen_entries,
     _resolve_pathogen_key,
     _load_sources_yaml,
 )
@@ -39,13 +41,15 @@ class TestYamlSourceLookup:
         results = lookup_yaml_sources(q, "pox_re_emerging_viruses")
         assert len(results) > 0
 
-    def test_unknown_pathogen_falls_back_to_family(self):
-        # An unrecognised pathogen under a family route falls back to the whole
-        # family (see _resolve_entries). Intentional best-effort behaviour;
-        # flagged for review in the route-gating follow-up issue.
+    def test_unknown_pathogen_under_family_returns_empty(self):
+        # An unrecognised pathogen under a family route returns nothing rather
+        # than flattening the whole family: injecting ebola + marburg dashboards
+        # for, say, a Lassa question would feed the insight stage wrong-pathogen
+        # case counts. The pipeline falls back to general_sources instead.
+        # (issue #41, finding #1)
         q = _make_question(pathogen="unknownvirus123")
         results = lookup_yaml_sources(q, "hemorrhagic")
-        assert len(results) > 0
+        assert results == []
 
     def test_no_pathogen_returns_empty(self):
         # No pathogen + a pathogen-specific route yields nothing; only the
@@ -103,6 +107,57 @@ class TestYamlSourceLookup:
             assert 0.0 <= r.domain_score <= 1.0
             assert r.freshness_score == 1.0
             assert r.search_stage_score == 0.0  # computed later by pipeline
+
+
+class TestPathogenFirstLookup:
+    """Deterministic pathogen-first resolution scans *all* families for
+    question.pathogen — no LLM route required (issue #41)."""
+
+    def test_resolves_across_families_without_route(self):
+        results = lookup_pathogen_sources(_make_question(pathogen="mpox"))
+        assert len(results) > 0
+        for r in results:
+            assert r.retrieval_reason == "dashboard_lookup"
+
+    def test_unset_pathogen_returns_empty(self):
+        assert lookup_pathogen_sources(_make_question(pathogen=None)) == []
+        assert resolve_pathogen_entries(_make_question(pathogen=None)) == []
+
+    def test_unrecognised_pathogen_returns_empty(self):
+        # No family match -> empty, so the pipeline falls back to general.
+        assert lookup_pathogen_sources(_make_question(pathogen="novel pathogen")) == []
+        assert resolve_pathogen_entries(_make_question(pathogen="unknownvirus123")) == []
+
+    def test_h5n1_mirrored_family_deduplicated(self):
+        # h5n1 is intentionally mirrored under `respiratory` and
+        # `animal_spillover`; a cross-family scan must not return duplicates.
+        entries = resolve_pathogen_entries(_make_question(pathogen="h5n1"))
+        ids = [e.get("id") for e in entries]
+        assert ids == list(dict.fromkeys(ids)), f"duplicate entries: {ids}"
+        urls = [e.get("url") for e in entries]
+        assert len(urls) == len(set(urls))
+
+    def test_alias_resolves_without_route(self):
+        # Free-text topic strings from the benchmark loader must resolve.
+        for text, canonical in [
+            ("avian influenza h5", "h5n1"),
+            ("sudan virus disease", "ebola"),
+            ("sars-cov-2", "covid-19"),
+            ("poliovirus", "polio"),
+        ]:
+            got = {r.url for r in lookup_pathogen_sources(_make_question(pathogen=text))}
+            want = {r.url for r in lookup_pathogen_sources(_make_question(pathogen=canonical))}
+            assert got == want and got, f"{text!r} did not resolve to {canonical!r}"
+
+    def test_pathogen_first_excludes_general_sources(self):
+        # Pathogen hit must not pull in the general baseline feeds.
+        general_urls = {
+            r.url for r in lookup_yaml_sources(_make_question(), "general_sources")
+        }
+        pathogen_urls = {
+            r.url for r in lookup_pathogen_sources(_make_question(pathogen="mpox"))
+        }
+        assert pathogen_urls.isdisjoint(general_urls)
 
 
 class TestResolvePathogenKey:

--- a/bioscancast/tests/test_search_pipeline.py
+++ b/bioscancast/tests/test_search_pipeline.py
@@ -180,3 +180,61 @@ class TestSearchStagePipeline:
         for r in dashboard_results:
             assert r.rank == 0
             assert r.engine == "dashboard"
+
+
+class TestSourceRoutingOrder:
+    """Issue #41: deterministic pathogen-first injection, LLM route as backup,
+    general sources only when nothing pathogen-specific is available."""
+
+    @staticmethod
+    def _pipeline():
+        return SearchStagePipeline(
+            search_backend=FakeSearchBackend(),
+            llm_client=FakeLLMClient(),
+            backend_name="fake",
+        )
+
+    def test_pathogen_hit_bypasses_llm_route(self, monkeypatch):
+        """A resolvable question.pathogen must inject curated sources without
+        ever consulting the LLM route."""
+        import bioscancast.stages.searching.pipeline as pipe
+
+        route_calls = {"n": 0}
+
+        def spy_route(question, llm_client):
+            route_calls["n"] += 1
+            return "general_sources"
+
+        monkeypatch.setattr(pipe, "route_sources", spy_route)
+
+        results = self._pipeline().run(_make_question())  # pathogen="H5N1"
+
+        assert route_calls["n"] == 0
+        dash = [r for r in results if r.retrieval_reason == "dashboard_lookup"]
+        assert dash and all("cdc.gov" in r.domain or "who.int" in r.domain or "aphis" in r.domain
+                            for r in dash)
+
+    def test_unset_pathogen_falls_back_to_general(self, monkeypatch):
+        """With no resolvable pathogen the LLM backup runs and general sources
+        are injected as the last resort."""
+        import bioscancast.stages.searching.pipeline as pipe
+
+        route_calls = {"n": 0}
+
+        def spy_route(question, llm_client):
+            route_calls["n"] += 1
+            return "general_sources"
+
+        monkeypatch.setattr(pipe, "route_sources", spy_route)
+
+        question = ForecastQuestion(
+            id="Q002",
+            text="Will WHO declare a PHEIC by December 2026?",
+            created_at=datetime(2025, 1, 15, tzinfo=timezone.utc),
+            pathogen=None,
+        )
+        results = self._pipeline().run(question)
+
+        assert route_calls["n"] == 1
+        dash = [r for r in results if r.retrieval_reason == "dashboard_lookup"]
+        assert dash, "expected general_sources to be injected as fallback"


### PR DESCRIPTION
Closes #41.

## What & why

Encodes the standing-meeting decision: **default/general sources are injected only when no pathogen-specific sources are available.** The structured `question.pathogen` field becomes the primary, deterministic routing gate; the LLM `route_sources()` call is kept as a backup for pathogen-unset / unrecognised questions.

`question.pathogen` is reliable enough to lead with — checked against both benchmark CSVs, it produces **zero misroutes and zero false-injects**: every curated topic resolves to the right pathogen (incl. aliases like `avian influenza h5`→h5n1, `sudan virus`→ebola, `sars-cov-2`→covid-19), and every genuinely-general topic (Novel pathogen, PHEIC, WHO DON, Mystery Outbreak) returns `None` and falls through.

## Routing order in `run()`

1. **Pathogen-first (deterministic):** scan *every* family for `question.pathogen`, inject the matches, skip general.
2. **LLM backup:** only if step 1 is empty, `route_sources()` picks a route.
3. **General:** last resort only.

## Changes

- Add `resolve_pathogen_entries()` / `lookup_pathogen_sources()` in `source_lookup.py`: cross-family scan with de-dup of the `h5n1` entries mirrored under `respiratory` + `animal_spillover`.
- `pipeline.run()`: pathogen-first → LLM backup → general fallback.
- **Remove flatten-on-unknown** (issue finding #1): an unresolved pathogen under a family now returns `[]` instead of injecting the whole family — a Lassa/CCHF question can no longer pick up ebola/marburg case counts.
- Tests: cross-family resolution, h5n1 dedup, general-suppression, and pipeline routing-order; the former `test_unknown_pathogen_falls_back_to_family` now asserts `[]`.

## Notes / follow-ups

- **`route_sources()` is now effectively vestigial** — with the all-family scan + no-flatten, the backup branch can only ever resolve to `general_sources` (any pathogen it could route would already be caught by the deterministic scan). **Kept for now** per discussion; candidate for removal in a follow-up. Net LLM cost still drops, since `route_sources()` now runs only on the pathogen-unset minority rather than every question.
- Findings #2 (Wayback cost on general sources) and #3 (domain-cap exemption) are unchanged; #2 is mitigated since general is injected less often now.
- Minor pre-existing nuance (out of scope): `Filovirus` resolves to ebola only, not marburg.

## Testing

Full suite green: `564 passed, 3 skipped`. Verified the live routing decision on all 19 benchmark topics matches the analysis (h5n1 correctly deduped to 4 sources).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
