### PR TITLE
Forecasting: optional prior-run history context (off by default)

### DIFF
--- a/bioscancast/main.py
+++ b/bioscancast/main.py
@@ -15,6 +15,7 @@ See ``--help`` for the full flag list.
 from __future__ import annotations
 
 import argparse
+import json
 import logging
 import os
 import sys
@@ -193,6 +194,12 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
         help="Disable the search-stage cache.",
     )
     parser.add_argument(
+        "--history-context",
+        action="store_true",
+        help="Enable prior-run forecast/insight context injection into forecasting "
+        "(off by default; pending further A/B evidence).",
+    )
+    parser.add_argument(
         "--max-input-tokens",
         type=int,
         default=None,
@@ -326,6 +333,175 @@ def _estimate_total_cost(per_model: dict[str, dict[str, int]]) -> tuple[float, l
     return total, warnings
 
 
+def _build_forecast_history_context(
+    out_root: Path,
+    question_id: str,
+    current_run_id: str,
+    *,
+    max_runs: int = 5,
+) -> str:
+    """Summarize prior forecast outputs for prompt context.
+
+    Pulls previous ``forecast.json`` + ``question.json`` artifacts for this
+    question and emits a compact text block the forecasting prompt can use as
+    historical context. Failures are best-effort and silently skipped.
+    """
+    qdir = out_root / question_id
+    if not qdir.exists() or not qdir.is_dir():
+        return ""
+
+    run_dirs = [p for p in qdir.iterdir() if p.is_dir() and p.name != current_run_id]
+    run_dirs.sort(key=lambda p: p.name, reverse=True)
+
+    lines: list[str] = []
+    for run_dir in run_dirs:
+        if len(lines) >= max_runs:
+            break
+        forecast_path = run_dir / "forecast.json"
+        question_path = run_dir / "question.json"
+        if not forecast_path.exists() or not question_path.exists():
+            continue
+
+        try:
+            forecast_payload = json.loads(forecast_path.read_text(encoding="utf-8"))
+            question_payload = json.loads(question_path.read_text(encoding="utf-8"))
+        except Exception:
+            continue
+
+        as_of = question_payload.get("as_of_date") or "(none)"
+        distributions = forecast_payload.get("distributions") or []
+        chosen = None
+        for d in distributions:
+            if d.get("forecast_source") == "bioscancast":
+                chosen = d
+                break
+        if chosen is None and distributions:
+            chosen = distributions[0]
+        if not chosen:
+            continue
+
+        probs = chosen.get("probabilities") or {}
+        if not probs:
+            continue
+        top_option = max(probs, key=probs.get)
+        top_prob = float(probs[top_option])
+        prob_parts = [f"{k}={float(v):.3f}" for k, v in probs.items()]
+
+        rationale = ""
+        samples = forecast_payload.get("samples") or []
+        for s in samples:
+            r = (s or {}).get("rationale")
+            if r:
+                rationale = str(r).strip()
+                break
+        if not rationale:
+            r = forecast_payload.get("baseline_rationale")
+            if r:
+                rationale = str(r).strip()
+
+        if len(rationale) > 240:
+            rationale = rationale[:237].rstrip() + "..."
+
+        line = (
+            f"- as_of={as_of} run={run_dir.name}: "
+            f"top={top_option} ({top_prob:.3f}); probs: "
+            f"{', '.join(prob_parts)}"
+        )
+        if rationale:
+            line += f"; rationale: {rationale}"
+        lines.append(line)
+
+    return "\n".join(lines)
+
+
+def _build_insight_history_context(
+    out_root: Path,
+    question_id: str,
+    current_run_id: str,
+    *,
+    max_runs: int = 3,
+    max_records_per_run: int = 3,
+) -> str:
+    """Summarize prior insight extracts for prompt context.
+
+    Each emitted line explicitly includes the prior scrape ``as_of`` date so
+    the forecasting model can distinguish historical snapshots from current
+    evidence.
+    """
+    qdir = out_root / question_id
+    if not qdir.exists() or not qdir.is_dir():
+        return ""
+
+    run_dirs = [p for p in qdir.iterdir() if p.is_dir() and p.name != current_run_id]
+    run_dirs.sort(key=lambda p: p.name, reverse=True)
+
+    lines: list[str] = []
+    runs_added = 0
+    for run_dir in run_dirs:
+        if runs_added >= max_runs:
+            break
+        insight_path = run_dir / "insight.json"
+        question_path = run_dir / "question.json"
+        if not insight_path.exists() or not question_path.exists():
+            continue
+
+        try:
+            insight_payload = json.loads(insight_path.read_text(encoding="utf-8"))
+            question_payload = json.loads(question_path.read_text(encoding="utf-8"))
+        except Exception:
+            continue
+
+        as_of = question_payload.get("as_of_date") or "(none)"
+        records = insight_payload.get("records") or []
+        if not isinstance(records, list) or not records:
+            continue
+
+        kept = 0
+        for rec in records:
+            if kept >= max_records_per_run:
+                break
+            if not isinstance(rec, dict):
+                continue
+
+            metric_name = rec.get("metric_name") or "(none)"
+            metric_value = rec.get("metric_value")
+            if metric_value is None:
+                metric_value_text = "n/a"
+            else:
+                metric_value_text = str(metric_value)
+            event_type = rec.get("event_type") or "other"
+            location = rec.get("location") or "(unknown)"
+            summary = (rec.get("summary") or "").strip()
+            if len(summary) > 140:
+                summary = summary[:137].rstrip() + "..."
+
+            quote = ""
+            sources = rec.get("sources") or []
+            if isinstance(sources, list) and sources:
+                first = sources[0]
+                if isinstance(first, dict):
+                    quote = (first.get("quote") or "").strip()
+            if len(quote) > 120:
+                quote = quote[:117].rstrip() + "..."
+
+            line = (
+                f"- past_scrape_as_of={as_of} run={run_dir.name}: "
+                f"event_type={event_type}, location={location}, "
+                f"metric={metric_name}, value={metric_value_text}"
+            )
+            if summary:
+                line += f"; summary: {summary}"
+            if quote:
+                line += f"; quote: {quote}"
+            lines.append(line)
+            kept += 1
+
+        if kept > 0:
+            runs_added += 1
+
+    return "\n".join(lines)
+
+
 # ----------------------------------------------------------------------------
 # Main pipeline
 # ----------------------------------------------------------------------------
@@ -402,6 +578,7 @@ def run_pipeline(args: argparse.Namespace) -> "ForecastResult | InsightRunResult
             "extraction": asdict(ExtractionConfig()),
             "insight": asdict(insight_config),
             "forecast": asdict(forecast_config),
+            "history_context": bool(args.history_context),
         },
         "forecast_options": options,
         "forecast_options_source": options_source,
@@ -513,12 +690,30 @@ def run_pipeline(args: argparse.Namespace) -> "ForecastResult | InsightRunResult
 
         if not args.no_forecast:
             with _stage_timer(manifest, "forecast"):
+                if args.history_context:
+                    historical_context = _build_forecast_history_context(
+                        out_root,
+                        question.id,
+                        run_id,
+                    )
+                    historical_insight_context = _build_insight_history_context(
+                        out_root,
+                        question.id,
+                        run_id,
+                    )
+                else:
+                    historical_context = ""
+                    historical_insight_context = ""
                 forecast_pipeline = ForecastingPipeline(
                     llm_client=shared_llm_raw,
                     config=forecast_config,
                 )
                 forecast_result = forecast_pipeline.run(
-                    question, insight_result.records, options,
+                    question,
+                    insight_result.records,
+                    options,
+                    historical_context=historical_context,
+                    historical_insight_context=historical_insight_context,
                 )
                 persistence.save_forecast(run_dir, forecast_result)
             stage_usage["forecast"] = (

--- a/bioscancast/stages/forecasting/pipeline.py
+++ b/bioscancast/stages/forecasting/pipeline.py
@@ -138,6 +138,8 @@ class ForecastingPipeline:
         question: ForecastQuestion,
         records: List[InsightRecord],
         options: List[str],
+        historical_context: str | None = None,
+        historical_insight_context: str | None = None,
     ) -> ForecastResult:
         """Produce a forecast distribution over ``options`` for ``question``.
 
@@ -168,7 +170,11 @@ class ForecastingPipeline:
 
         # --- Ensemble of superforecaster reasoning samples ---
         system, user, schema = build_forecast_prompt(
-            question, options, evidence_digest
+            question,
+            options,
+            evidence_digest,
+            historical_context,
+            historical_insight_context,
         )
         usable_vectors: List[List[float]] = []
         for i in range(config.ensemble_samples):

--- a/bioscancast/stages/forecasting/prompts.py
+++ b/bioscancast/stages/forecasting/prompts.py
@@ -121,6 +121,8 @@ def build_forecast_prompt(
     question: ForecastQuestion,
     options: List[str],
     evidence_digest: str,
+    historical_context: str | None = None,
+    historical_insight_context: str | None = None,
 ) -> Tuple[str, str, dict]:
     """Build the (system, user, json_schema) tuple for one reasoning sample.
 
@@ -153,6 +155,22 @@ def build_forecast_prompt(
         f"  {i}. {opt}" for i, opt in enumerate(options)
     )
     parts.append(f"OPTIONS (assign a probability to each, in this order):\n{numbered_options}")
+
+    if historical_context:
+        parts.append("")
+        parts.append(
+            "FORECAST HISTORY (prior runs for this question; use as context, "
+            "not as a substitute for current evidence):"
+        )
+        parts.append(historical_context)
+
+    if historical_insight_context:
+        parts.append("")
+        parts.append(
+            "PAST INSIGHT SCRAPES (from prior runs; each line includes the "
+            "scrape as-of date):"
+        )
+        parts.append(historical_insight_context)
 
     parts.append("")
     if evidence_digest:

--- a/bioscancast/tests/test_forecast_history_context.py
+++ b/bioscancast/tests/test_forecast_history_context.py
@@ -1,0 +1,484 @@
+from __future__ import annotations
+
+import json
+
+import bioscancast.main as orchestrator
+from bioscancast.main import (
+    _build_forecast_history_context,
+    _build_insight_history_context,
+)
+from bioscancast.stages.forecasting.schemas import (
+    ForecastDistribution,
+    ForecastRecord,
+    ForecastResult,
+)
+from bioscancast.stages.insight.pipeline import InsightRunResult
+
+
+def _write_json(path, payload):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def test_build_forecast_history_context_reads_prior_runs(tmp_path):
+    qid = "q-hist"
+    current = "20260714_120000"
+
+    old_run = tmp_path / qid / "20260701_000000"
+    _write_json(
+        old_run / "question.json",
+        {"id": qid, "as_of_date": "2026-07-01T00:00:00+00:00"},
+    )
+    _write_json(
+        old_run / "forecast.json",
+        {
+            "distributions": [
+                {
+                    "forecast_source": "bioscancast",
+                    "probabilities": {"YES": 0.72, "NO": 0.28},
+                }
+            ],
+            "samples": [
+                {"ok": True, "rationale": "cases rose over prior two weeks"}
+            ],
+            "baseline_rationale": "prior-only baseline",
+        },
+    )
+
+    context = _build_forecast_history_context(tmp_path, qid, current)
+
+    assert "as_of=2026-07-01T00:00:00+00:00" in context
+    assert "top=YES (0.720)" in context
+    assert "rationale: cases rose over prior two weeks" in context
+
+
+def test_build_forecast_history_context_skips_current_run(tmp_path):
+    qid = "q-hist"
+    current = "20260714_120000"
+
+    cur_run = tmp_path / qid / current
+    _write_json(cur_run / "question.json", {"id": qid, "as_of_date": "2026-07-14"})
+    _write_json(
+        cur_run / "forecast.json",
+        {
+            "distributions": [
+                {
+                    "forecast_source": "bioscancast",
+                    "probabilities": {"YES": 0.99, "NO": 0.01},
+                }
+            ],
+            "samples": [{"ok": True, "rationale": "current run"}],
+        },
+    )
+
+    context = _build_forecast_history_context(tmp_path, qid, current)
+    assert context == ""
+
+
+def test_build_insight_history_context_reads_prior_scrape_dates(tmp_path):
+    qid = "q-hist"
+    current = "20260714_120000"
+
+    old_run = tmp_path / qid / "20260701_000000"
+    _write_json(
+        old_run / "question.json",
+        {"id": qid, "as_of_date": "2026-07-01T00:00:00+00:00"},
+    )
+    _write_json(
+        old_run / "insight.json",
+        {
+            "records": [
+                {
+                    "event_type": "case_count",
+                    "location": "Uganda",
+                    "metric_name": "confirmed_cases",
+                    "metric_value": 42,
+                    "summary": "Weekly increase in confirmed cases",
+                    "sources": [{"quote": "42 confirmed cases"}],
+                }
+            ]
+        },
+    )
+
+    context = _build_insight_history_context(tmp_path, qid, current)
+    assert "past_scrape_as_of=2026-07-01T00:00:00+00:00" in context
+    assert "metric=confirmed_cases, value=42" in context
+    assert "summary: Weekly increase in confirmed cases" in context
+
+
+def test_orchestrator_passes_history_block_when_enabled(tmp_path, monkeypatch):
+    qid = "q-int"
+    current = "20260714_120000"
+
+    # Two prior runs for the same question.
+    for run_id, as_of, probs, rationale in (
+        ("20260712_000000", "2026-07-12T00:00:00+00:00", {"YES": 0.7, "NO": 0.3}, "uptick continued"),
+        ("20260710_000000", "2026-07-10T00:00:00+00:00", {"YES": 0.6, "NO": 0.4}, "signals mixed"),
+    ):
+        rdir = tmp_path / qid / run_id
+        _write_json(rdir / "question.json", {"id": qid, "as_of_date": as_of})
+        _write_json(
+            rdir / "forecast.json",
+            {
+                "distributions": [
+                    {
+                        "forecast_source": "bioscancast",
+                        "probabilities": probs,
+                    }
+                ],
+                "samples": [{"ok": True, "rationale": rationale}],
+            },
+        )
+        _write_json(
+            rdir / "insight.json",
+            {
+                "records": [
+                    {
+                        "event_type": "case_count",
+                        "location": "Uganda",
+                        "metric_name": "confirmed_cases",
+                        "metric_value": 10 if "0712" in run_id else 8,
+                        "summary": "Prior scrape saw growth",
+                        "sources": [{"quote": "confirmed cases reported"}],
+                    }
+                ]
+            },
+        )
+
+    # Unrelated question history must not be included.
+    other = tmp_path / "q-other" / "20260711_000000"
+    _write_json(other / "question.json", {"id": "q-other", "as_of_date": "2026-07-11"})
+    _write_json(
+        other / "forecast.json",
+        {
+            "distributions": [
+                {
+                    "forecast_source": "bioscancast",
+                    "probabilities": {"YES": 0.99, "NO": 0.01},
+                }
+            ],
+            "samples": [{"ok": True, "rationale": "other question"}],
+        },
+    )
+    _write_json(
+        other / "insight.json",
+        {
+            "records": [
+                {
+                    "event_type": "case_count",
+                    "location": "Other",
+                    "metric_name": "confirmed_cases",
+                    "metric_value": 999,
+                    "summary": "other question",
+                    "sources": [{"quote": "other question"}],
+                }
+            ]
+        },
+    )
+
+    captured: dict[str, str | None] = {
+        "history": None,
+        "insight_history": None,
+    }
+
+    class _DummyLLM:
+        def generate_json(self, **kwargs):  # pragma: no cover
+            raise AssertionError("LLM should not be called in this stubbed test")
+
+        def embed(self, texts, *, model):
+            return [[0.0] * 4 for _ in texts]
+
+    class _DummyBackend:
+        pass
+
+    class _SearchStagePipeline:
+        def __init__(self, **kwargs):
+            pass
+
+        def run(self, question):
+            return []
+
+    class _FilteringPipeline:
+        def __init__(self, **kwargs):
+            pass
+
+        def run(self, question, search_results):
+            return []
+
+    class _ExtractionPipeline:
+        def __init__(self, **kwargs):
+            self.docling_telemetry = []
+
+        def run(self, filtered_docs):
+            return []
+
+    class _InsightPipeline:
+        def __init__(self, **kwargs):
+            pass
+
+        def run(self, question, documents):
+            return InsightRunResult(
+                records=[],
+                budget_summary={
+                    "total_input_tokens": 0,
+                    "total_output_tokens": 0,
+                    "per_model": {},
+                },
+                documents_processed=0,
+                documents_skipped=0,
+                notes=[],
+            )
+
+    class _ForecastingPipeline:
+        def __init__(self, **kwargs):
+            pass
+
+        def run(
+            self,
+            question,
+            records,
+            options,
+            historical_context=None,
+            historical_insight_context=None,
+        ):
+            captured["history"] = historical_context
+            captured["insight_history"] = historical_insight_context
+            return ForecastResult(
+                question_id=question.id,
+                options=list(options),
+                distributions=[
+                    ForecastDistribution(
+                        question_id=question.id,
+                        forecast_source="bioscancast",
+                        probabilities={"YES": 0.5, "NO": 0.5},
+                    )
+                ],
+                records=[
+                    ForecastRecord(
+                        question_id=question.id,
+                        forecast_source="bioscancast",
+                        option="YES",
+                        probability=0.5,
+                    ),
+                    ForecastRecord(
+                        question_id=question.id,
+                        forecast_source="bioscancast",
+                        option="NO",
+                        probability=0.5,
+                    ),
+                ],
+                budget_summary={
+                    "total_input_tokens": 0,
+                    "total_output_tokens": 0,
+                    "per_model": {},
+                },
+            )
+
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    monkeypatch.setenv("TAVILY_API_KEY", "test-key")
+    monkeypatch.setattr(orchestrator, "OpenAILLMClient", _DummyLLM)
+    monkeypatch.setattr(orchestrator, "TavilyBackend", _DummyBackend)
+    monkeypatch.setattr(orchestrator, "SearchStagePipeline", _SearchStagePipeline)
+    monkeypatch.setattr(orchestrator, "FilteringPipeline", _FilteringPipeline)
+    monkeypatch.setattr(orchestrator, "ExtractionPipeline", _ExtractionPipeline)
+    monkeypatch.setattr(orchestrator, "InsightPipeline", _InsightPipeline)
+    monkeypatch.setattr(orchestrator, "ForecastingPipeline", _ForecastingPipeline)
+
+    args = orchestrator._parse_args(
+        [
+            qid,
+            "--question",
+            "Will cases exceed threshold?",
+            "--out-root",
+            str(tmp_path),
+            "--run-id",
+            current,
+            "--options",
+            "YES,NO",
+            "--no-baseline",
+            "--no-cache",
+            "--history-context",
+        ]
+    )
+
+    orchestrator.run_pipeline(args)
+
+    history = captured["history"] or ""
+    insight_history = captured["insight_history"] or ""
+    assert "as_of=2026-07-12T00:00:00+00:00" in history
+    assert "as_of=2026-07-10T00:00:00+00:00" in history
+    assert "rationale: uptick continued" in history
+    assert "rationale: signals mixed" in history
+    assert "other question" not in history
+    assert "past_scrape_as_of=2026-07-12T00:00:00+00:00" in insight_history
+    assert "past_scrape_as_of=2026-07-10T00:00:00+00:00" in insight_history
+    assert "metric=confirmed_cases" in insight_history
+    assert "other question" not in insight_history
+
+
+def test_orchestrator_history_context_off_by_default(tmp_path, monkeypatch):
+    # No --history-context flag: prior-run context must NOT be injected.
+    qid = "q-int"
+    current = "20260714_130000"
+
+    prior = tmp_path / qid / "20260712_000000"
+    _write_json(
+        prior / "question.json",
+        {"id": qid, "as_of_date": "2026-07-12T00:00:00+00:00"},
+    )
+    _write_json(
+        prior / "forecast.json",
+        {
+            "distributions": [
+                {
+                    "forecast_source": "bioscancast",
+                    "probabilities": {"YES": 0.7, "NO": 0.3},
+                }
+            ],
+            "samples": [{"ok": True, "rationale": "uptick continued"}],
+        },
+    )
+    _write_json(
+        prior / "insight.json",
+        {
+            "records": [
+                {
+                    "event_type": "case_count",
+                    "location": "Uganda",
+                    "metric_name": "confirmed_cases",
+                    "metric_value": 10,
+                    "summary": "Prior scrape saw growth",
+                    "sources": [{"quote": "confirmed cases reported"}],
+                }
+            ]
+        },
+    )
+
+    captured: dict[str, str | None] = {
+        "history": None,
+        "insight_history": None,
+    }
+
+    class _DummyLLM:
+        def generate_json(self, **kwargs):  # pragma: no cover
+            raise AssertionError("LLM should not be called in this stubbed test")
+
+        def embed(self, texts, *, model):
+            return [[0.0] * 4 for _ in texts]
+
+    class _DummyBackend:
+        pass
+
+    class _SearchStagePipeline:
+        def __init__(self, **kwargs):
+            pass
+
+        def run(self, question):
+            return []
+
+    class _FilteringPipeline:
+        def __init__(self, **kwargs):
+            pass
+
+        def run(self, question, search_results):
+            return []
+
+    class _ExtractionPipeline:
+        def __init__(self, **kwargs):
+            self.docling_telemetry = []
+
+        def run(self, filtered_docs):
+            return []
+
+    class _InsightPipeline:
+        def __init__(self, **kwargs):
+            pass
+
+        def run(self, question, documents):
+            return InsightRunResult(
+                records=[],
+                budget_summary={
+                    "total_input_tokens": 0,
+                    "total_output_tokens": 0,
+                    "per_model": {},
+                },
+                documents_processed=0,
+                documents_skipped=0,
+                notes=[],
+            )
+
+    class _ForecastingPipeline:
+        def __init__(self, **kwargs):
+            pass
+
+        def run(
+            self,
+            question,
+            records,
+            options,
+            historical_context=None,
+            historical_insight_context=None,
+        ):
+            captured["history"] = historical_context
+            captured["insight_history"] = historical_insight_context
+            return ForecastResult(
+                question_id=question.id,
+                options=list(options),
+                distributions=[
+                    ForecastDistribution(
+                        question_id=question.id,
+                        forecast_source="bioscancast",
+                        probabilities={"YES": 0.5, "NO": 0.5},
+                    )
+                ],
+                records=[
+                    ForecastRecord(
+                        question_id=question.id,
+                        forecast_source="bioscancast",
+                        option="YES",
+                        probability=0.5,
+                    ),
+                    ForecastRecord(
+                        question_id=question.id,
+                        forecast_source="bioscancast",
+                        option="NO",
+                        probability=0.5,
+                    ),
+                ],
+                budget_summary={
+                    "total_input_tokens": 0,
+                    "total_output_tokens": 0,
+                    "per_model": {},
+                },
+            )
+
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    monkeypatch.setenv("TAVILY_API_KEY", "test-key")
+    monkeypatch.setattr(orchestrator, "OpenAILLMClient", _DummyLLM)
+    monkeypatch.setattr(orchestrator, "TavilyBackend", _DummyBackend)
+    monkeypatch.setattr(orchestrator, "SearchStagePipeline", _SearchStagePipeline)
+    monkeypatch.setattr(orchestrator, "FilteringPipeline", _FilteringPipeline)
+    monkeypatch.setattr(orchestrator, "ExtractionPipeline", _ExtractionPipeline)
+    monkeypatch.setattr(orchestrator, "InsightPipeline", _InsightPipeline)
+    monkeypatch.setattr(orchestrator, "ForecastingPipeline", _ForecastingPipeline)
+
+    args = orchestrator._parse_args(
+        [
+            qid,
+            "--question",
+            "Will cases exceed threshold?",
+            "--out-root",
+            str(tmp_path),
+            "--run-id",
+            current,
+            "--options",
+            "YES,NO",
+            "--no-baseline",
+            "--no-cache",
+        ]
+    )
+
+    orchestrator.run_pipeline(args)
+
+    assert (captured["history"] or "") == ""
+    assert (captured["insight_history"] or "") == ""

--- a/bioscancast/tests/test_forecasting_pipeline.py
+++ b/bioscancast/tests/test_forecasting_pipeline.py
@@ -15,7 +15,9 @@ from bioscancast.stages.filtering.models import ForecastQuestion
 from bioscancast.stages.forecasting import aggregation
 from bioscancast.stages.forecasting.config import ForecastingConfig
 from bioscancast.stages.forecasting.evidence import build_evidence_digest, _format_record
+from bioscancast.stages.forecasting.prompts import build_forecast_prompt
 from bioscancast.stages.forecasting.pipeline import ForecastingPipeline
+import bioscancast.stages.forecasting.pipeline as forecasting_pipeline_mod
 from bioscancast.stages.forecasting.schemas import ForecastResult
 from bioscancast.llm.base import LLMResponse
 from bioscancast.llm.fake_client import FakeLLMClient
@@ -459,6 +461,90 @@ def test_pipeline_rejects_empty_options():
     pipeline = ForecastingPipeline(llm_client=client, config=_config())
     with pytest.raises(ValueError):
         pipeline.run(QUESTION, [_record()], [])
+
+
+def test_prompt_includes_forecast_history_block_when_provided():
+    system, user, schema = build_forecast_prompt(
+        QUESTION,
+        ["YES", "NO"],
+        evidence_digest="[2026-01-15] sample evidence",
+        historical_context=(
+            "- as_of=2026-01-01 run=20260101_000000: top=NO (0.620); "
+            "probs: YES=0.380, NO=0.620; rationale: outbreak appears contained"
+        ),
+    )
+    assert "FORECAST HISTORY (prior runs for this question" in user
+    assert "as_of=2026-01-01" in user
+    assert "rationale: outbreak appears contained" in user
+
+
+def test_prompt_includes_past_insight_scrape_block_when_provided():
+    system, user, schema = build_forecast_prompt(
+        QUESTION,
+        ["YES", "NO"],
+        evidence_digest="[2026-01-15] sample evidence",
+        historical_insight_context=(
+            "- past_scrape_as_of=2026-01-03 run=20260103_000000: "
+            "event_type=case_count, location=Uganda, metric=confirmed_cases, "
+            "value=12; summary: Weekly increase observed"
+        ),
+    )
+    assert "PAST INSIGHT SCRAPES (from prior runs" in user
+    assert "past_scrape_as_of=2026-01-03" in user
+    assert "Weekly increase observed" in user
+
+
+def test_pipeline_threads_historical_context_into_prompt(monkeypatch):
+    captured: dict[str, str | None] = {
+        "historical_context": None,
+        "historical_insight_context": None,
+    }
+    original = forecasting_pipeline_mod.build_forecast_prompt
+
+    def _recording_build_prompt(
+        question,
+        options,
+        evidence_digest,
+        historical_context=None,
+        historical_insight_context=None,
+    ):
+        captured["historical_context"] = historical_context
+        captured["historical_insight_context"] = historical_insight_context
+        return original(
+            question,
+            options,
+            evidence_digest,
+            historical_context,
+            historical_insight_context,
+        )
+
+    monkeypatch.setattr(
+        forecasting_pipeline_mod,
+        "build_forecast_prompt",
+        _recording_build_prompt,
+    )
+
+    client = FakeLLMClient([_forecast_resp([0.6, 0.4])])
+    pipeline = ForecastingPipeline(
+        llm_client=client,
+        config=_config(ensemble_samples=1, emit_baseline=False),
+    )
+    pipeline.run(
+        QUESTION,
+        [_record()],
+        ["YES", "NO"],
+        historical_context="- as_of=2026-01-01 run=old: top=NO (0.620)",
+        historical_insight_context=(
+            "- past_scrape_as_of=2026-01-02 run=older: metric=confirmed_cases, value=7"
+        ),
+    )
+
+    assert captured["historical_context"] is not None
+    assert "as_of=2026-01-01" in (captured["historical_context"] or "")
+    assert captured["historical_insight_context"] is not None
+    assert "past_scrape_as_of=2026-01-02" in (
+        captured["historical_insight_context"] or ""
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 rank-bm25
 numpy
+pandas>=2.0 # DataFrame ops in the evaluation stage and the custom Tableau/CSV scrapers (USDA APHIS, PAHO Oropouche)
 
 curl_cffi>=0.7,<1.0 # HTTP client with streaming support and browser TLS-fingerprint impersonation (Cloudflare workaround)
 trafilatura>=1.12,<2.0 # HTML main-content extraction (strips nav, ads, boilerplate)

--- a/scripts/run_historical_trajectory.py
+++ b/scripts/run_historical_trajectory.py
@@ -124,6 +124,11 @@ def _parse_args(argv: List[str]) -> argparse.Namespace:
     p.add_argument("--no-baseline", action="store_true", help="Skip the retrieval-free baseline.")
     p.add_argument("--no-cache", action="store_true", help="Disable the search-stage cache.")
     p.add_argument(
+        "--history-context",
+        action="store_true",
+        help="Enable prior-run forecast/insight context during forecasting (off by default).",
+    )
+    p.add_argument(
         "--max-input-tokens", type=int, default=None,
         help="Override InsightConfig.max_input_tokens_per_run.",
     )
@@ -181,6 +186,8 @@ def _run_one_cutoff(
         orch_argv.append("--no-baseline")
     if args.no_cache:
         orch_argv.append("--no-cache")
+    if args.history_context:
+        orch_argv.append("--history-context")
     if args.max_input_tokens is not None:
         orch_argv += ["--max-input-tokens", str(args.max_input_tokens)]
     if args.verbose:


### PR DESCRIPTION
Extracted from @rapsoj's #69.

## What
Adds `_build_forecast_history_context` / `_build_insight_history_context`, which summarize prior sibling runs' forecast and insight outputs and inject them into the forecast prompt (`ForecastingPipeline.run` / `build_forecast_prompt` gain optional `historical_context` / `historical_insight_context` arguments).

## Off by default
The feature is opt-in via a new `--history-context` flag; the CLI default is **off**, pending further A/B evidence (early Q1 testing in #69 showed a slightly worse Brier score with history injected). `scripts/run_historical_trajectory.py` gains the matching pass-through flag.

## Not included
The ~18k lines of committed A/B run artifacts from #69 (`data/runs_ab_*`) are intentionally omitted — the tests build their own temporary fixtures.

## Also
Adds `pandas` to `requirements.txt` (already imported by the evaluation stage; needed to run the forecasting tests). Full suite green; two tests cover default-off and flag-on behaviour.
